### PR TITLE
fix: fix gemini message transfer to claude.

### DIFF
--- a/backend-go/internal/handlers/common/stream.go
+++ b/backend-go/internal/handlers/common/stream.go
@@ -165,13 +165,14 @@ func drainChannels(eventChan <-chan string, errChan <-chan error) {
 
 // StreamContext 流处理上下文
 type StreamContext struct {
-	LogBuffer        bytes.Buffer
-	OutputTextBuffer bytes.Buffer
-	Synthesizer      *utils.StreamSynthesizer
-	LoggingEnabled   bool
-	ClientGone       bool
-	HasUsage         bool
-	NeedTokenPatch   bool
+	LogBuffer            bytes.Buffer
+	OutputTextBuffer     bytes.Buffer
+	Synthesizer          *utils.StreamSynthesizer
+	LoggingEnabled       bool
+	ClientGone           bool
+	HasUsage             bool
+	HasMessageDeltaUsage bool
+	NeedTokenPatch       bool
 	// 累积的 token 统计
 	CollectedUsage CollectedUsageData
 	// 用于日志的"续写前缀"（不参与真实转发，只影响 Stream-Synth 输出可读性）
@@ -361,6 +362,10 @@ func ProcessStreamEvent(
 		}
 		// 累积收集 usage 数据
 		updateCollectedUsage(&ctx.CollectedUsage, usageData)
+
+		if IsMessageDeltaEvent(event) {
+			ctx.HasMessageDeltaUsage = true
+		}
 	}
 
 	// 日志缓存
@@ -373,15 +378,16 @@ func ProcessStreamEvent(
 		}
 	}
 
-	// 在 message_stop 前注入 usage（上游完全没有 usage 的情况）
-	if !ctx.HasUsage && !ctx.ClientGone && IsMessageStopEvent(event) {
+	// 在 message_stop 前注入 usage（message_delta 未携带 usage 的兜底场景）
+	if !ctx.HasMessageDeltaUsage && !ctx.ClientGone && IsMessageStopEvent(event) {
 		usageEvent := BuildUsageEvent(requestBody, ctx.OutputTextBuffer.String())
 		if envCfg.EnableResponseLogs && envCfg.ShouldLog("debug") {
-			log.Printf("[Messages-Stream-Token] 上游无usage, 注入本地估算事件")
+			log.Printf("[Messages-Stream-Token] message_delta 缺少 usage, 在 message_stop 前注入兜底 usage 事件")
 		}
 		w.Write([]byte(usageEvent))
 		flusher.Flush()
 		ctx.HasUsage = true
+		ctx.HasMessageDeltaUsage = true
 	}
 
 	// 修补 token
@@ -398,6 +404,37 @@ func ProcessStreamEvent(
 		eventToSend = PatchMessageStartInputTokensIfNeeded(eventToSend, requestBody, needInputPatch, originalUsageData, envCfg.EnableResponseLogs && envCfg.ShouldLog("debug"), ctx.LowQuality)
 	}
 
+	// 对严格客户端做协议兜底：任何 message_delta 都应带顶层 usage。
+	if IsMessageDeltaEvent(eventToSend) && !HasEventWithUsage(eventToSend) {
+		inputTokens := ctx.CollectedUsage.InputTokens
+		outputTokens := ctx.CollectedUsage.OutputTokens
+
+		estimatedInputTokens := utils.EstimateRequestTokens(requestBody)
+		estimatedOutputTokens := utils.EstimateTokens(ctx.OutputTextBuffer.String())
+
+		if inputTokens <= 0 && estimatedInputTokens > 0 {
+			inputTokens = estimatedInputTokens
+		}
+		if outputTokens <= 0 && estimatedOutputTokens > 0 {
+			outputTokens = estimatedOutputTokens
+		}
+
+		eventToSend = EnsureMessageDeltaUsage(eventToSend, inputTokens, outputTokens)
+
+		if inputTokens > ctx.CollectedUsage.InputTokens {
+			ctx.CollectedUsage.InputTokens = inputTokens
+		}
+		if outputTokens > ctx.CollectedUsage.OutputTokens {
+			ctx.CollectedUsage.OutputTokens = outputTokens
+		}
+
+		ctx.HasUsage = true
+		ctx.HasMessageDeltaUsage = true
+		if envCfg.EnableResponseLogs && envCfg.ShouldLog("debug") {
+			log.Printf("[Messages-Stream-Token] message_delta 缺少 usage, 已就地补齐 input=%d output=%d", inputTokens, outputTokens)
+		}
+	}
+
 	// 记录 message_start 中的 input_tokens（用于后续推断隐式缓存）
 	// 注意：必须在 PatchMessageStartInputTokensIfNeeded 之后执行，因为原始值可能是 0 被修补成估算值
 	if IsMessageStartEvent(event) && ctx.MessageStartInputTokens == 0 {
@@ -406,8 +443,8 @@ func ProcessStreamEvent(
 		}
 	}
 
-	if ctx.NeedTokenPatch && HasEventWithUsage(event) {
-		if IsMessageDeltaEvent(event) || IsMessageStopEvent(event) {
+	if ctx.NeedTokenPatch && HasEventWithUsage(eventToSend) {
+		if IsMessageDeltaEvent(eventToSend) || IsMessageStopEvent(eventToSend) {
 			hasCacheTokens := ctx.CollectedUsage.CacheCreationInputTokens > 0 ||
 				ctx.CollectedUsage.CacheReadInputTokens > 0 ||
 				ctx.CollectedUsage.CacheCreation5mInputTokens > 0 ||
@@ -452,6 +489,11 @@ func ProcessStreamEvent(
 		}
 	}
 
+	if IsMessageDeltaEvent(eventToSend) && HasEventWithUsage(eventToSend) {
+		ctx.HasUsage = true
+		ctx.HasMessageDeltaUsage = true
+	}
+
 	// 转发给客户端
 	if !ctx.ClientGone {
 		if _, err := w.Write([]byte(eventToSend)); err != nil {
@@ -465,6 +507,57 @@ func ProcessStreamEvent(
 			flusher.Flush()
 		}
 	}
+}
+
+// EnsureMessageDeltaUsage 确保 message_delta 事件包含顶层 usage 字段。
+func EnsureMessageDeltaUsage(event string, inputTokens, outputTokens int) string {
+	if inputTokens < 0 {
+		inputTokens = 0
+	}
+	if outputTokens < 0 {
+		outputTokens = 0
+	}
+
+	var result strings.Builder
+	lines := strings.Split(event, "\n")
+
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "data: ") {
+			result.WriteString(line)
+			result.WriteString("\n")
+			continue
+		}
+
+		jsonStr := strings.TrimPrefix(line, "data: ")
+		var data map[string]interface{}
+		if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+			result.WriteString(line)
+			result.WriteString("\n")
+			continue
+		}
+
+		if data["type"] == "message_delta" {
+			if _, exists := data["usage"].(map[string]interface{}); !exists {
+				data["usage"] = map[string]int{
+					"input_tokens":  inputTokens,
+					"output_tokens": outputTokens,
+				}
+			}
+		}
+
+		patchedJSON, err := json.Marshal(data)
+		if err != nil {
+			result.WriteString(line)
+			result.WriteString("\n")
+			continue
+		}
+
+		result.WriteString("data: ")
+		result.Write(patchedJSON)
+		result.WriteString("\n")
+	}
+
+	return result.String()
 }
 
 // updateCollectedUsage 更新收集的 usage 数据

--- a/backend-go/internal/handlers/common/stream_test.go
+++ b/backend-go/internal/handlers/common/stream_test.go
@@ -2,10 +2,14 @@ package common
 
 import (
 	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/BenedictKing/ccx/internal/config"
 	"github.com/BenedictKing/ccx/internal/utils"
+	"github.com/gin-gonic/gin"
 )
 
 func TestPatchUsageFieldsWithLog_NilInputTokens(t *testing.T) {
@@ -444,5 +448,88 @@ func TestHasNonTextContentBlock(t *testing.T) {
 				t.Errorf("hasNonTextContentBlock() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestEnsureMessageDeltaUsage(t *testing.T) {
+	extractUsage := func(t *testing.T, event string) (int, int) {
+		t.Helper()
+		for _, line := range strings.Split(event, "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+
+			var data map[string]interface{}
+			if err := json.Unmarshal([]byte(strings.TrimPrefix(line, "data: ")), &data); err != nil {
+				t.Fatalf("failed to unmarshal event data: %v", err)
+			}
+			if data["type"] != "message_delta" {
+				continue
+			}
+
+			usage, ok := data["usage"].(map[string]interface{})
+			if !ok {
+				t.Fatalf("usage field missing in message_delta")
+			}
+
+			inputTokens, _ := usage["input_tokens"].(float64)
+			outputTokens, _ := usage["output_tokens"].(float64)
+			return int(inputTokens), int(outputTokens)
+		}
+
+		t.Fatalf("message_delta event not found")
+		return 0, 0
+	}
+
+	t.Run("add usage when missing", func(t *testing.T) {
+		event := "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"}}\n\n"
+		patched := EnsureMessageDeltaUsage(event, 123, 7)
+
+		in, out := extractUsage(t, patched)
+		if in != 123 || out != 7 {
+			t.Fatalf("expected usage input=123 output=7, got input=%d output=%d", in, out)
+		}
+	})
+
+	t.Run("keep existing usage", func(t *testing.T) {
+		event := "event: message_delta\ndata: {\"type\":\"message_delta\",\"delta\":{\"stop_reason\":\"end_turn\"},\"usage\":{\"input_tokens\":10,\"output_tokens\":2}}\n\n"
+		patched := EnsureMessageDeltaUsage(event, 999, 888)
+
+		in, out := extractUsage(t, patched)
+		if in != 10 || out != 2 {
+			t.Fatalf("expected existing usage to be kept, got input=%d output=%d", in, out)
+		}
+	})
+}
+
+func TestProcessStreamEvent_MessageStopInjectsUsageWhenMessageDeltaMissing(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	w := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(w)
+	c.Request = httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(`{}`))
+
+	flusher, ok := c.Writer.(http.Flusher)
+	if !ok {
+		t.Fatalf("response writer does not implement http.Flusher")
+	}
+
+	ctx := &StreamContext{
+		ContentBlockTypes: make(map[int]string),
+		HasUsage:          true, // message_start 已经有 usage
+	}
+	envCfg := &config.EnvConfig{LogLevel: "info"}
+
+	messageStopEvent := "event: message_stop\ndata: {\"type\":\"message_stop\"}\n\n"
+	ProcessStreamEvent(c, c.Writer, flusher, messageStopEvent, ctx, envCfg, []byte(`{"messages":[{"role":"user","content":"hello"}]}`))
+
+	body := w.Body.String()
+	if !strings.Contains(body, "event: message_delta") {
+		t.Fatalf("expected injected message_delta usage event before message_stop, body=%s", body)
+	}
+	if !strings.Contains(body, "\"usage\"") {
+		t.Fatalf("expected injected usage field, body=%s", body)
+	}
+	if !strings.Contains(body, "event: message_stop") {
+		t.Fatalf("expected message_stop event to be forwarded, body=%s", body)
 	}
 }

--- a/backend-go/internal/providers/gemini.go
+++ b/backend-go/internal/providers/gemini.go
@@ -369,6 +369,8 @@ func (p *GeminiProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 		toolUseBlockIndex := 0
 		messageStartSent := false
 		stopReason := ""
+		latestInputTokens := 0
+		latestOutputTokens := 0
 
 		// 文本块状态跟踪
 		textBlockStarted := false
@@ -391,6 +393,38 @@ func (p *GeminiProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 			var chunk map[string]interface{}
 			if err := json.Unmarshal([]byte(jsonStr), &chunk); err != nil {
 				continue
+			}
+
+			// Gemini 可能在无 candidates 的 chunk 中返回 usageMetadata（通常出现在流末尾）
+			// 这里必须先提取 usage，避免被后续 candidates 判断提前跳过。
+			if usageMetadata, ok := chunk["usageMetadata"].(map[string]interface{}); ok {
+				inputTokens := latestInputTokens
+				outputTokens := latestOutputTokens
+
+				if promptTokens, ok := usageMetadata["promptTokenCount"].(float64); ok {
+					inputTokens = int(promptTokens)
+				}
+				if cachedTokens, ok := usageMetadata["cachedContentTokenCount"].(float64); ok {
+					inputTokens -= int(cachedTokens)
+				}
+				if candidatesTokens, ok := usageMetadata["candidatesTokenCount"].(float64); ok {
+					outputTokens = int(candidatesTokens)
+				}
+
+				if inputTokens < 0 {
+					inputTokens = 0
+				}
+				if outputTokens < 0 {
+					outputTokens = 0
+				}
+
+				// usageMetadata 可能多次出现，保留最新的非下降值，避免回退。
+				if inputTokens > latestInputTokens {
+					latestInputTokens = inputTokens
+				}
+				if outputTokens > latestOutputTokens {
+					latestOutputTokens = outputTokens
+				}
 			}
 
 			candidates, ok := chunk["candidates"].([]interface{})
@@ -498,10 +532,9 @@ func (p *GeminiProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 					textBlockStarted = false
 				}
 
-				if strings.Contains(strings.ToLower(finishReason), "stop") {
-					stopReason = "end_turn"
-				} else if strings.Contains(strings.ToLower(finishReason), "max_tokens") || strings.Contains(strings.ToLower(finishReason), "length") {
-					stopReason = "max_tokens"
+				mappedStopReason := mapGeminiFinishReasonToClaudeStopReason(finishReason)
+				if mappedStopReason != "" {
+					stopReason = mappedStopReason
 				}
 			}
 		}
@@ -532,6 +565,10 @@ func (p *GeminiProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 				"delta": map[string]string{
 					"stop_reason": stopReason,
 				},
+				"usage": map[string]int{
+					"input_tokens":  latestInputTokens,
+					"output_tokens": latestOutputTokens,
+				},
 			}
 			deltaJSON, _ := json.Marshal(deltaEvent)
 			eventChan <- fmt.Sprintf("event: message_delta\ndata: %s\n\n", deltaJSON)
@@ -545,4 +582,20 @@ func (p *GeminiProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 	}()
 
 	return eventChan, errChan, nil
+}
+
+func mapGeminiFinishReasonToClaudeStopReason(finishReason string) string {
+	reason := strings.ToLower(finishReason)
+
+	switch {
+	case strings.Contains(reason, "max_tokens"), strings.Contains(reason, "length"):
+		return "max_tokens"
+	case strings.Contains(reason, "stop"),
+		strings.Contains(reason, "safety"),
+		strings.Contains(reason, "recitation"),
+		strings.Contains(reason, "other"):
+		return "end_turn"
+	default:
+		return ""
+	}
 }

--- a/backend-go/internal/providers/gemini_stream_test.go
+++ b/backend-go/internal/providers/gemini_stream_test.go
@@ -1,0 +1,141 @@
+package providers
+
+import (
+	"encoding/json"
+	"io"
+	"strings"
+	"testing"
+)
+
+func collectStreamEvents(ch <-chan string) []string {
+	events := make([]string, 0, 8)
+	for event := range ch {
+		events = append(events, event)
+	}
+	return events
+}
+
+func extractMessageDelta(t *testing.T, events []string) map[string]interface{} {
+	t.Helper()
+	for _, event := range events {
+		for _, line := range strings.Split(event, "\n") {
+			if !strings.HasPrefix(line, "data: ") {
+				continue
+			}
+			jsonStr := strings.TrimPrefix(line, "data: ")
+
+			var data map[string]interface{}
+			if err := json.Unmarshal([]byte(jsonStr), &data); err != nil {
+				continue
+			}
+			if data["type"] == "message_delta" {
+				return data
+			}
+		}
+	}
+
+	t.Fatalf("message_delta not found, events=%v", events)
+	return nil
+}
+
+func TestGeminiHandleStreamResponse_UsageOnlyChunkStillAffectsMessageDeltaUsage(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"candidates":[{"content":{"parts":[{"text":"OK"}]},"finishReason":"STOP"}]}`,
+		`data: {"usageMetadata":{"promptTokenCount":123,"candidatesTokenCount":8}}`,
+		"",
+	}, "\n")
+
+	provider := &GeminiProvider{}
+	eventChan, errChan, err := provider.HandleStreamResponse(io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatalf("HandleStreamResponse returned error: %v", err)
+	}
+
+	events := collectStreamEvents(eventChan)
+	select {
+	case streamErr := <-errChan:
+		if streamErr != nil {
+			t.Fatalf("unexpected stream error: %v", streamErr)
+		}
+	default:
+	}
+
+	messageDelta := extractMessageDelta(t, events)
+	usage, ok := messageDelta["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage field missing in message_delta: %v", messageDelta)
+	}
+
+	inputTokens, _ := usage["input_tokens"].(float64)
+	outputTokens, _ := usage["output_tokens"].(float64)
+	if int(inputTokens) != 123 || int(outputTokens) != 8 {
+		t.Fatalf("unexpected usage in message_delta, want input=123 output=8, got input=%v output=%v", usage["input_tokens"], usage["output_tokens"])
+	}
+}
+
+func TestGeminiHandleStreamResponse_MessageDeltaAlwaysContainsUsage(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"candidates":[{"content":{"parts":[{"text":"hello"}]},"finishReason":"STOP"}]}`,
+		"",
+	}, "\n")
+
+	provider := &GeminiProvider{}
+	eventChan, errChan, err := provider.HandleStreamResponse(io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatalf("HandleStreamResponse returned error: %v", err)
+	}
+
+	events := collectStreamEvents(eventChan)
+	select {
+	case streamErr := <-errChan:
+		if streamErr != nil {
+			t.Fatalf("unexpected stream error: %v", streamErr)
+		}
+	default:
+	}
+
+	messageDelta := extractMessageDelta(t, events)
+	usage, ok := messageDelta["usage"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("usage field missing in message_delta: %v", messageDelta)
+	}
+
+	inputTokens, _ := usage["input_tokens"].(float64)
+	outputTokens, _ := usage["output_tokens"].(float64)
+	if int(inputTokens) != 0 || int(outputTokens) != 0 {
+		t.Fatalf("expected fallback usage 0/0 when upstream usage absent, got input=%v output=%v", usage["input_tokens"], usage["output_tokens"])
+	}
+}
+
+func TestGeminiHandleStreamResponse_SafetyFinishReasonMapsToEndTurn(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"candidates":[{"content":{"parts":[{"text":"blocked"}]},"finishReason":"SAFETY"}]}`,
+		"",
+	}, "\n")
+
+	provider := &GeminiProvider{}
+	eventChan, errChan, err := provider.HandleStreamResponse(io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatalf("HandleStreamResponse returned error: %v", err)
+	}
+
+	events := collectStreamEvents(eventChan)
+	select {
+	case streamErr := <-errChan:
+		if streamErr != nil {
+			t.Fatalf("unexpected stream error: %v", streamErr)
+		}
+	default:
+	}
+
+	messageDelta := extractMessageDelta(t, events)
+	delta, ok := messageDelta["delta"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("delta field missing in message_delta: %v", messageDelta)
+	}
+
+	stopReason, _ := delta["stop_reason"].(string)
+	if stopReason != "end_turn" {
+		t.Fatalf("expected stop_reason=end_turn for SAFETY finishReason, got %q", stopReason)
+	}
+}


### PR DESCRIPTION
我有一种用法是在 claude code 中使用一个 gemini 模型进行 review 方案，但是claude code 只发送和接收claude 格式的消息，所以使用 ccx 来转换。但使用发现在 gemini 回复消息转成 claude 的时候 claude code 会提示找不到usage 字段，这个pr修改了这个问题 