### PR TITLE
fix(providers): normalize SSE field lines for upstream compatibility

### DIFF
--- a/backend-go/internal/providers/claude.go
+++ b/backend-go/internal/providers/claude.go
@@ -152,7 +152,7 @@ func (p *ClaudeProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 		}
 
 		for scanner.Scan() {
-			line := scanner.Text()
+			line := normalizeSSEFieldLine(scanner.Text())
 
 			// 检测是否发送了 tool_use 相关的 stop_reason（通常在 data 行中）
 			if strings.Contains(line, `"stop_reason":"tool_use"`) ||

--- a/backend-go/internal/providers/provider.go
+++ b/backend-go/internal/providers/provider.go
@@ -3,6 +3,7 @@ package providers
 import (
 	"io"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/BenedictKing/ccx/internal/config"
@@ -21,6 +22,19 @@ type Provider interface {
 
 	// HandleStreamResponse 处理流式响应
 	HandleStreamResponse(body io.ReadCloser) (<-chan string, <-chan error, error)
+}
+
+// normalizeSSEFieldLine 标准化 SSE 字段行的格式
+// SSE 规范允许 "data:value" 和 "data: value" 两种格式，
+// 但下游解析统一使用 "data: " 前缀，因此需要标准化。
+// 例如: "data:{...}" → "data: {...}", "event:message_start" → "event: message_start"
+func normalizeSSEFieldLine(line string) string {
+	for _, prefix := range []string{"data:", "event:", "id:", "retry:"} {
+		if strings.HasPrefix(line, prefix) && !strings.HasPrefix(line, prefix+" ") {
+			return prefix + " " + line[len(prefix):]
+		}
+	}
+	return line
 }
 
 func newDefaultSessionManager() *session.SessionManager {


### PR DESCRIPTION
## Summary

- Some upstream providers (e.g. Kimi) return SSE events without a space after the colon (`data:{...}` instead of `data: {...}`). Both formats are valid per the [SSE specification](https://html.spec.whatwg.org/multipage/server-sent-events.html), but CCX's downstream parsing functions expect `data: ` with a space.
- This caused `PreflightStreamEvents` to fail to extract text content, misidentifying valid responses as empty and triggering `ErrEmptyStreamResponse` — even though the upstream returned a correct 200 response with content.
- Added `normalizeSSEFieldLine()` in `provider.go` and applied it in `ClaudeProvider.HandleStreamResponse` to standardize SSE field lines (`data:`, `event:`, `id:`, `retry:`) before forwarding to event channels.

## Test plan

- [x] `go test ./internal/providers/...` — passed
- [x] `go test ./internal/handlers/...` — all 6 sub-packages passed
- [ ] Manual test with Kimi upstream (`POST /v1/messages`) to verify stream is no longer rejected as empty