### PR TITLE
feat: binary self-update with pre-flight verification and progress bar

### DIFF
--- a/backend-go/health_check.go
+++ b/backend-go/health_check.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/gin-gonic/gin"
+)
+
+// runHealthCheck starts a minimal HTTP server that only exposes /health
+// on a random localhost port. Used by the updater's pre-flight validation
+// to verify that a newly downloaded binary starts correctly.
+//
+// This mode initializes nothing (no config, no logger, no metrics) so it
+// starts and responds quickly. It exits automatically after 5 seconds.
+func runHealthCheck() {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.GET("/health", func(c *gin.Context) {
+		c.JSON(200, gin.H{
+			"status": "ok",
+			"version": gin.H{
+				"version": Version,
+			},
+		})
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "FATAL: cannot bind health check port: %v\n", err)
+		os.Exit(1)
+	}
+	port := listener.Addr().(*net.TCPAddr).Port
+	// Write directly to stdout and sync to ensure the parent process
+	// receives the READY signal immediately (required on Windows where
+	// pipe output may be buffered).
+	fmt.Fprintf(os.Stdout, "READY:%d\n", port)
+	os.Stdout.Sync()
+
+	// Auto-exit after 5 seconds so the process doesn't orphan.
+	go func() {
+		time.Sleep(5 * time.Second)
+		os.Exit(0)
+	}()
+
+	if err := http.Serve(listener, r); err != nil {
+		fmt.Fprintf(os.Stderr, "health check serve error: %v\n", err)
+		os.Exit(1)
+	}
+}

--- a/backend-go/internal/config/config.go
+++ b/backend-go/internal/config/config.go
@@ -151,9 +151,9 @@ type UpstreamUpdate struct {
 	// 路由前缀
 	RoutePrefix *string `json:"routePrefix"` // 路由前缀（如 "kimi"）
 	// Vision 能力配置
-	NoVision            *bool             `json:"noVision"`
-	NoVisionModels      []string          `json:"noVisionModels"`
-	VisionFallbackModel *string `json:"visionFallbackModel"`
+	NoVision            *bool    `json:"noVision"`
+	NoVisionModels      []string `json:"noVisionModels"`
+	VisionFallbackModel *string  `json:"visionFallbackModel"`
 }
 
 // Config 配置结构

--- a/backend-go/internal/handlers/version_handler.go
+++ b/backend-go/internal/handlers/version_handler.go
@@ -1,0 +1,159 @@
+package handlers
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/BenedictKing/ccx/internal/config"
+	"github.com/BenedictKing/ccx/internal/updater"
+	"github.com/gin-gonic/gin"
+	"golang.org/x/mod/semver"
+)
+
+var (
+	updateInProgress atomic.Bool
+
+	updateStatus   = "idle"
+	updateErrorMsg = ""
+	updateProgress = 0
+	updateMu       sync.RWMutex
+)
+
+func setUpdateState(status, errMsg string, progress int) {
+	updateMu.Lock()
+	updateStatus = status
+	updateErrorMsg = errMsg
+	updateProgress = progress
+	updateMu.Unlock()
+}
+
+func getUpdateState() (string, string, int) {
+	updateMu.RLock()
+	defer updateMu.RUnlock()
+	return updateStatus, updateErrorMsg, updateProgress
+}
+
+// VersionCheckHandler returns the current version and the latest GitHub release.
+func VersionCheckHandler(envCfg *config.EnvConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		currentVersion := versionString
+
+		info, err := updater.CheckLatest("BenedictKing", "ccx")
+		if err != nil {
+			c.JSON(http.StatusOK, gin.H{
+				"current": gin.H{
+					"version":   currentVersion,
+					"buildTime": buildTime,
+					"gitCommit": gitCommit,
+				},
+				"latest":    nil,
+				"hasUpdate": false,
+				"error":     err.Error(),
+			})
+			return
+		}
+
+		hasUpdate := true
+		if currentVersion != "v0.0.0-dev" {
+			if semver.Compare(currentVersion, info.Version) >= 0 {
+				hasUpdate = false
+			}
+		}
+
+		c.JSON(http.StatusOK, gin.H{
+			"current": gin.H{
+				"version":   currentVersion,
+				"buildTime": buildTime,
+				"gitCommit": gitCommit,
+			},
+			"latest": gin.H{
+				"version":     info.Version,
+				"publishedAt": info.PublishedAt,
+				"url":         info.HTMLURL,
+			},
+			"hasUpdate": hasUpdate,
+		})
+	}
+}
+
+// VersionStatusHandler returns the current update progress for frontend polling.
+func VersionStatusHandler(envCfg *config.EnvConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		status, errMsg, progress := getUpdateState()
+		c.JSON(http.StatusOK, gin.H{
+			"status":   status,
+			"error":    errMsg,
+			"progress": progress,
+		})
+	}
+}
+
+// VersionUpdateHandler triggers the update process.
+func VersionUpdateHandler(envCfg *config.EnvConfig) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !updateInProgress.CompareAndSwap(false, true) {
+			c.JSON(http.StatusConflict, gin.H{
+				"status":  "error",
+				"message": "更新已在进行中",
+			})
+			return
+		}
+
+		currentVersion := versionString
+		log.Printf("[VersionUpdate] starting update from %s", currentVersion)
+
+		c.JSON(http.StatusOK, gin.H{
+			"status":  "updating",
+			"message": "更新已开始，服务即将重启",
+		})
+		c.Writer.Flush()
+
+		go func() {
+			defer func() {
+				if r := recover(); r != nil {
+					log.Printf("[VersionUpdate] panic: %v", r)
+					setUpdateState("failed", fmt.Sprintf("panic: %v", r), 0)
+				}
+				updateInProgress.Store(false)
+			}()
+
+			setUpdateState("downloading", "", 0)
+
+			// Progress ticker: advances during download, self-terminates
+			// when status changes away from "downloading".
+			go func() {
+				ticker := time.NewTicker(800 * time.Millisecond)
+				defer ticker.Stop()
+				for range ticker.C {
+					st, _, p := getUpdateState()
+					if st != "downloading" {
+						return
+					}
+					if p < 60 {
+						setUpdateState("downloading", "", p+4)
+					}
+				}
+			}()
+
+			onProgress := func(status string, progress int) {
+				setUpdateState(status, "", progress)
+			}
+
+			err := updater.DoUpdate("BenedictKing", "ccx", currentVersion, onProgress)
+
+			if err != nil {
+				log.Printf("[VersionUpdate] update failed: %v", err)
+				setUpdateState("failed", err.Error(), 0)
+				return
+			}
+
+			// DoUpdate returned nil: already at latest version
+			log.Println("[VersionUpdate] already up-to-date")
+			setUpdateState("idle", "", 100)
+		}()
+	}
+}

--- a/backend-go/internal/middleware/auth.go
+++ b/backend-go/internal/middleware/auth.go
@@ -20,6 +20,18 @@ func WebAuthMiddleware(envCfg *config.EnvConfig, cfgManager *config.ConfigManage
 			return
 		}
 
+		// 版本检查端点公开访问
+		if path == "/api/version/check" {
+			c.Next()
+			return
+		}
+
+		// 更新状态端点公开访问
+		if path == "/api/version/status" {
+			c.Next()
+			return
+		}
+
 		// 静态资源文件直接放行
 		if isStaticResource(path) {
 			c.Next()

--- a/backend-go/internal/updater/updater.go
+++ b/backend-go/internal/updater/updater.go
@@ -1,0 +1,349 @@
+// Package updater provides binary self-update for CCX.
+//
+// Flow: CheckLatest -> DownloadBinary -> preFlightCheck -> selfReplace -> exit.
+// Linux and Windows share all logic except the final selfReplace step.
+package updater
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+)
+
+const (
+	githubAPI        = "https://api.github.com/repos/%s/%s/releases?per_page=10"
+	downloadTimeout  = 300 * time.Second
+	preFlightTimeout = 5 * time.Second
+)
+
+// ReleaseInfo describes a GitHub Release suitable for updating.
+type ReleaseInfo struct {
+	Version     string `json:"version"`     // e.g. "v2.7.0"
+	DownloadURL string `json:"downloadUrl"` // asset download URL for this platform
+	PublishedAt string `json:"publishedAt"` // ISO-8601
+	HTMLURL     string `json:"htmlUrl"`     // GitHub release page
+}
+
+// githubRelease is the raw JSON structure returned by the GitHub API.
+type githubRelease struct {
+	TagName     string        `json:"tag_name"`
+	HTMLURL     string        `json:"html_url"`
+	PublishedAt string        `json:"published_at"`
+	Prerelease  bool          `json:"prerelease"`
+	Assets      []githubAsset `json:"assets"`
+}
+
+type githubAsset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+// AssetName returns the expected release asset filename for the running OS/arch.
+func AssetName() string {
+	arch := runtime.GOARCH
+	switch runtime.GOOS {
+	case "linux":
+		return "ccx-linux-" + arch
+	case "windows":
+		return "ccx-windows-" + arch + ".exe"
+	case "darwin":
+		return "ccx-darwin-" + arch
+	default:
+		return ""
+	}
+}
+
+// CheckLatest queries GitHub for the latest stable release of the given repo.
+// It skips prereleases and returns the first stable release found.
+func CheckLatest(owner, repo string) (*ReleaseInfo, error) {
+	url := fmt.Sprintf(githubAPI, owner, repo)
+	log.Printf("[Updater] checking latest release: %s/%s", owner, repo)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request failed: %w", err)
+	}
+	req.Header.Set("User-Agent", "ccx/"+runtime.GOOS+"-"+runtime.GOARCH)
+	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GitHub API request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 403 || resp.StatusCode == 429 {
+		return nil, fmt.Errorf("GitHub API rate limit exceeded (HTTP %d)", resp.StatusCode)
+	}
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("GitHub API returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading GitHub response failed: %w", err)
+	}
+
+	var releases []githubRelease
+	if err := json.Unmarshal(body, &releases); err != nil {
+		return nil, fmt.Errorf("parsing GitHub response failed: %w", err)
+	}
+
+	// Find the first stable release with a matching asset.
+	myAsset := AssetName()
+	if myAsset == "" {
+		return nil, fmt.Errorf("unsupported platform: %s/%s", runtime.GOOS, runtime.GOARCH)
+	}
+
+	for _, rel := range releases {
+		if rel.Prerelease || isPrereleaseTag(rel.TagName) {
+			continue
+		}
+		for _, asset := range rel.Assets {
+			if asset.Name == myAsset {
+				return &ReleaseInfo{
+					Version:     rel.TagName,
+					DownloadURL: asset.BrowserDownloadURL,
+					PublishedAt: rel.PublishedAt,
+					HTMLURL:     rel.HTMLURL,
+				}, nil
+			}
+		}
+	}
+	return nil, fmt.Errorf("no stable release with asset %q found", myAsset)
+}
+
+// DownloadBinary streams a binary from downloadURL to destPath.
+// It verifies minimum file size and sets executable permission.
+func DownloadBinary(downloadURL, destPath string) error {
+	log.Printf("[Updater] downloading %s -> %s", downloadURL, destPath)
+
+	client := &http.Client{Timeout: downloadTimeout}
+	resp, err := client.Get(downloadURL)
+	if err != nil {
+		return fmt.Errorf("download request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("download returned HTTP %d", resp.StatusCode)
+	}
+
+	tmpPath := destPath + ".download" // download to .download then rename atomically
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		return fmt.Errorf("creating temp file failed: %w", err)
+	}
+
+	written, err := io.Copy(f, resp.Body)
+	if err != nil {
+		f.Close()
+		os.Remove(tmpPath)
+		return fmt.Errorf("download failed: %w", err)
+	}
+	f.Close()
+
+	if written < 1024*1024 { // refuse files smaller than 1 MB
+		os.Remove(tmpPath)
+		return fmt.Errorf("downloaded file too small (%d bytes), likely an error page", written)
+	}
+
+	if err := os.Chmod(tmpPath, 0755); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("chmod failed: %w", err)
+	}
+	if err := os.Rename(tmpPath, destPath); err != nil {
+		os.Remove(tmpPath)
+		return fmt.Errorf("rename failed: %w", err)
+	}
+
+	log.Printf("[Updater] download complete: %d bytes", written)
+	return nil
+}
+
+// preFlightCheck starts the binary at binaryPath in --health-check mode,
+// waits for the READY signal, sends a GET /health, and verifies the version.
+// It kills the child process and returns nil on success.
+func preFlightCheck(binaryPath, expectedVersion string) error {
+	log.Printf("[Updater] pre-flight check: %s (expecting %s)", binaryPath, expectedVersion)
+
+	cmd := exec.Command(binaryPath, "--health-check")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("stdout pipe failed: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting health-check binary failed: %w", err)
+	}
+	defer cmd.Process.Kill()
+
+	// Read the port from stdout (READY:<port>\n)
+	portCh := make(chan int, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		var line string
+		for scanner.Scan() {
+			line = scanner.Text()
+			if strings.HasPrefix(line, "READY:") {
+				break
+			}
+		}
+		err := scanner.Err()
+		if err != nil {
+			errCh <- fmt.Errorf("reading READY signal failed: %w", err)
+			return
+		}
+		if !strings.HasPrefix(line, "READY:") {
+			// Child process does not support --health-check mode.
+			// This happens when updating to a version released before
+			// the self-update feature was added. Skip pre-flight check
+			// but still verify the binary exists and is executable.
+			log.Printf("[Updater] pre-flight: binary does not support --health-check, skipping health verification")
+			portCh <- -1 // sentinel: skip health check
+			return
+		}
+		port, err := strconv.Atoi(line[6:])
+		if err != nil {
+			errCh <- fmt.Errorf("parsing port from %q failed: %w", line, err)
+			return
+		}
+		portCh <- port
+	}()
+
+	var port int
+	select {
+	case port = <-portCh:
+		if port == -1 {
+			// Binary doesn't support --health-check mode;
+			// accept the downloaded binary as valid (it passed size check).
+			log.Println("[Updater] pre-flight check skipped (binary predates health-check support)")
+			return nil
+		}
+	case err := <-errCh:
+		return err
+	case <-time.After(preFlightTimeout):
+		cmd.Process.Kill()
+		return fmt.Errorf("timed out waiting for health-check to start")
+	}
+
+	// GET /health
+	healthURL := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	client := &http.Client{Timeout: 3 * time.Second}
+	resp, err := client.Get(healthURL)
+	if err != nil {
+		return fmt.Errorf("health check request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return fmt.Errorf("health check returned HTTP %d", resp.StatusCode)
+	}
+
+	var healthData struct {
+		Status  string `json:"status"`
+		Version struct {
+			Version string `json:"version"`
+		} `json:"version"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&healthData); err != nil {
+		return fmt.Errorf("parsing health response failed: %w", err)
+	}
+	if healthData.Status != "ok" {
+		return fmt.Errorf("health check status is %q", healthData.Status)
+	}
+	if healthData.Version.Version != expectedVersion {
+		return fmt.Errorf("version mismatch: got %q, expected %q",
+			healthData.Version.Version, expectedVersion)
+	}
+
+	log.Printf("[Updater] pre-flight check passed: version %s", expectedVersion)
+	return nil
+}
+
+// DoUpdate orchestrates the full update: check, download, pre-flight, replace.
+// On success it calls selfReplace which terminates the process; on error
+// it returns the error to the caller.
+
+// ProgressFunc is called at key milestones during an update.
+// status: "downloading" | "verifying" | "done"
+// progress: 0-100
+type ProgressFunc func(status string, progress int)
+
+// DoUpdate orchestrates the full update: check, download, pre-flight, replace.
+// onProgress is called at milestones; may be nil.
+// On success it calls selfReplace which terminates the process; on error
+// it returns the error to the caller.
+func DoUpdate(owner, repo, currentVersion string, onProgress ProgressFunc) error {
+	// 1. Check latest
+	release, err := CheckLatest(owner, repo)
+	if err != nil {
+		return fmt.Errorf("version check failed: %w", err)
+	}
+
+	if onProgress != nil {
+		onProgress("downloading", 5)
+	}
+
+	// 2. Compare versions
+	if currentVersion != "v0.0.0-dev" && semver.Compare(currentVersion, release.Version) >= 0 {
+		log.Printf("[Updater] already at latest version: %s", currentVersion)
+		return nil
+	}
+	log.Printf("[Updater] updating %s -> %s", currentVersion, release.Version)
+
+	// 3. Resolve paths
+	exePath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("cannot determine executable path: %w", err)
+	}
+	exeDir := filepath.Dir(exePath)
+	newPath := filepath.Join(exeDir, filepath.Base(exePath)+".new")
+
+	// 4. Download
+	if err := DownloadBinary(release.DownloadURL, newPath); err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+
+	if onProgress != nil {
+		onProgress("verifying", 65)
+	}
+
+	// 5. Pre-flight verification
+	if err := preFlightCheck(newPath, release.Version); err != nil {
+		os.Remove(newPath)
+		return fmt.Errorf("pre-flight verification failed: %v", err)
+	}
+
+	if onProgress != nil {
+		onProgress("done", 100)
+	}
+
+	// 6. Self-replace (platform-specific, terminates process)
+	selfReplace(exePath, newPath)
+	return nil
+}
+
+// isPrereleaseTag returns true if the tag contains prerelease indicators.
+func isPrereleaseTag(tag string) bool {
+	lower := strings.ToLower(tag)
+	for _, s := range []string{"-alpha", "-beta", "-rc", "-dev", "-pre", "-canary", "-nightly"} {
+		if strings.Contains(lower, s) {
+			return true
+		}
+	}
+	return false
+}

--- a/backend-go/internal/updater/updater_test.go
+++ b/backend-go/internal/updater/updater_test.go
@@ -1,0 +1,49 @@
+package updater
+
+import (
+	"testing"
+)
+
+func TestAssetName(t *testing.T) {
+	name := AssetName()
+	if name == "" {
+		t.Fatal("AssetName() returned empty string")
+	}
+	// At minimum it should start with "ccx-"
+	if len(name) < 4 || name[:4] != "ccx-" {
+		t.Fatalf("AssetName() = %q, want prefix ccx-", name)
+	}
+}
+
+func TestIsPrereleaseTag(t *testing.T) {
+	tests := []struct {
+		tag  string
+		want bool
+	}{
+		{"v2.6.89", false},
+		{"v2.7.0", false},
+		{"v2.7.0-rc1", true},
+		{"v2.7.0-beta", true},
+		{"v2.7.0-alpha.1", true},
+		{"v3.0.0-dev", true},
+		{"v3.0.0-canary", true},
+		{"v3.0.0-nightly.20260513", true},
+	}
+	for _, tt := range tests {
+		got := isPrereleaseTag(tt.tag)
+		if got != tt.want {
+			t.Errorf("isPrereleaseTag(%q) = %v, want %v", tt.tag, got, tt.want)
+		}
+	}
+}
+
+// TestDoUpdateNoop exercises the version comparison path without
+// actually performing an update (requires a real GitHub API call).
+// This is a smoke test for CheckLatest + version comparison.
+func TestDoUpdateNoopOnSameVersion(t *testing.T) {
+	t.Log("Skipping: would require live GitHub API access")
+	// In a real environment you would run:
+	//   info, err := CheckLatest("BenedictKing", "ccx")
+	//   if err != nil { t.Fatal(err) }
+	//   t.Logf("latest: %s (published: %s)", info.Version, info.PublishedAt)
+}

--- a/backend-go/internal/updater/updater_unix.go
+++ b/backend-go/internal/updater/updater_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package updater
+
+import (
+	"log"
+	"os"
+)
+
+// selfReplace replaces the running binary on Linux/macOS.
+//
+// Linux allows renaming over a running executable because the kernel
+// keeps the old inode alive for the running process. After os.Exit(0)
+// the service manager (systemd, launchd) restarts from the new inode.
+//
+// A backup (.old) is kept for rollback.
+func selfReplace(currentPath, newPath string) {
+	// Keep a backup for rollback.
+	oldPath := currentPath + ".old"
+	if err := os.Rename(currentPath, oldPath); err != nil {
+		log.Printf("[Updater] warning: backup rename failed (continuing): %v", err)
+	}
+
+	// Replace running binary.
+	if err := os.Rename(newPath, currentPath); err != nil {
+		log.Printf("[Updater] ERROR: replace rename failed: %v", err)
+		// Try to restore from backup.
+		os.Rename(oldPath, currentPath)
+		os.Exit(1)
+	}
+
+	// Remove old backup now that the new binary is in place.
+	_ = os.Remove(oldPath)
+
+	log.Println("[Updater] replace complete, exiting for service manager restart")
+	// Use os.Exit(0) on Unix -- the service manager (systemd) uses
+	// Restart=always and will restart the process with the new binary.
+	os.Exit(0)
+}

--- a/backend-go/internal/updater/updater_windows.go
+++ b/backend-go/internal/updater/updater_windows.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package updater
+
+import (
+	"log"
+	"os"
+)
+
+// selfReplace replaces the running binary on Windows.
+//
+// Windows does not allow deleting or overwriting a running .exe, but
+// it *does* allow renaming it. The strategy:
+//  1. Rename the current exe to .old (releases the original file name).
+//  2. Rename .new to the original exe name.
+//  3. Exit with code 1 so that SCM triggers its failure restart action
+//     and relaunches the new binary.
+//
+// A backup (.old) is kept for rollback.
+func selfReplace(currentPath, newPath string) {
+	// Rename current -> .old (releases the filename lock).
+	oldPath := currentPath + ".old"
+	if err := os.Rename(currentPath, oldPath); err != nil {
+		log.Printf("[Updater] warning: backup rename failed (continuing): %v", err)
+	}
+
+	// Rename .new -> current.
+	if err := os.Rename(newPath, currentPath); err != nil {
+		log.Printf("[Updater] ERROR: replace rename failed: %v", err)
+		// Try to restore from backup.
+		if err2 := os.Rename(oldPath, currentPath); err2 != nil {
+			log.Printf("[Updater] FATAL: restore from backup also failed: %v. Manual recovery required.", err2)
+		}
+		os.Exit(1)
+	}
+
+	// Remove backup.
+	_ = os.Remove(oldPath)
+
+	log.Println("[Updater] replace complete, exiting with code 1 for SCM restart")
+	// Use os.Exit(1) on Windows so SCM detects a failure and triggers
+	// its restart action, launching the new binary.
+	os.Exit(1)
+}

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -44,12 +44,43 @@ func main() {
 				fmt.Printf("git commit: %s\n", GitCommit)
 			}
 			os.Exit(0)
+		case "--health-check":
+			runHealthCheck()
+			return
+		case "--install":
+			exePath, _ := os.Executable()
+			if err := installService("ccx", "CCX API Gateway", exePath); err != nil {
+				log.Fatalf("Service install failed: %v", err)
+			}
+			return
+		case "--uninstall":
+			if err := removeService("ccx"); err != nil {
+				log.Fatalf("Service remove failed: %v", err)
+			}
+			return
+		case "--start":
+			if err := startService("ccx"); err != nil {
+				log.Fatalf("Service start failed: %v", err)
+			}
+			return
+		case "--stop":
+			if err := stopService("ccx"); err != nil {
+				log.Fatalf("Service stop failed: %v", err)
+			}
+			return
 		}
 	}
-
 	// 加载环境变量
 	if err := godotenv.Load(); err != nil {
 		log.Println("没有找到 .env 文件，使用环境变量或默认值")
+	}
+
+	// Windows SCM service mode: run as Windows service
+	if isWindowsService() {
+		if err := runService("ccx"); err != nil {
+			log.Fatalf("Service run failed: %v", err)
+		}
+		return
 	}
 
 	// 设置版本信息到 handlers 包
@@ -260,6 +291,11 @@ func main() {
 	r.Use(middleware.GzipMiddleware())
 
 	// Web UI 访问控制中间件
+
+	// 版本检查端点（公开，无需认证，必须在 WebAuthMiddleware 之前注册）
+	r.GET("/api/version/check", handlers.VersionCheckHandler(envCfg))
+	r.GET("/api/version/status", handlers.VersionStatusHandler(envCfg))
+
 	r.Use(middleware.WebAuthMiddleware(envCfg, cfgManager))
 
 	// 健康检查端点（固定路径 /health，与 Dockerfile HEALTHCHECK 保持一致）
@@ -438,6 +474,9 @@ func main() {
 		// 移除计费头设置
 		apiGroup.GET("/settings/strip-billing-header", handlers.GetStripBillingHeader(cfgManager))
 		apiGroup.PUT("/settings/strip-billing-header", handlers.SetStripBillingHeader(cfgManager))
+
+		// 版本信息与自更新
+		apiGroup.POST("/version/update", handlers.VersionUpdateHandler(envCfg))
 	}
 
 	// 代理端点 - Messages API

--- a/backend-go/service_stub.go
+++ b/backend-go/service_stub.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package main
+
+import "fmt"
+
+func installService(name, displayName, exePath string) error {
+	return fmt.Errorf("service commands (--install/--uninstall/--start/--stop) are only supported on Windows")
+}
+
+func removeService(name string) error {
+	return fmt.Errorf("service commands are only supported on Windows")
+}
+
+func startService(name string) error {
+	return fmt.Errorf("service commands are only supported on Windows")
+}
+
+func stopService(name string) error {
+	return fmt.Errorf("service commands are only supported on Windows")
+}
+
+func isWindowsService() bool { return false }
+
+func runService(name string) error {
+	return fmt.Errorf("service mode is only supported on Windows")
+}

--- a/backend-go/service_windows.go
+++ b/backend-go/service_windows.go
@@ -1,0 +1,161 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"log"
+	"os/exec"
+	"time"
+
+	"golang.org/x/sys/windows/svc"
+	"golang.org/x/sys/windows/svc/mgr"
+)
+
+// installService registers the current executable as a Windows service.
+func installService(name, displayName, exePath string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("SCM connect failed: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.CreateService(name, exePath, mgr.Config{
+		StartType:   mgr.StartAutomatic,
+		DisplayName: displayName,
+		Description: "CCX API Gateway - AI API Proxy and Protocol Translation Gateway",
+	})
+	if err != nil {
+		return fmt.Errorf("service create failed: %w", err)
+	}
+	defer s.Close()
+
+	// Set recovery actions via sc.exe (3 restarts at 30s intervals, then stop)
+	// mgr.Config does not expose recovery actions directly.
+	if err := exec.Command("sc", "failure", name,
+		"reset=86400",
+		"actions=restart/30000/restart/30000/restart/30000",
+	).Run(); err != nil {
+		log.Printf("[Service] warning: failed to set recovery actions: %v", err)
+	}
+
+	log.Printf("[Service] service %q installed: %s", name, exePath)
+	return nil
+}
+
+// removeService deletes the service from SCM.
+func removeService(name string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("SCM connect failed: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(name)
+	if err != nil {
+		return fmt.Errorf("service %q not found: %w", name, err)
+	}
+	defer s.Close()
+
+	if err := s.Delete(); err != nil {
+		return fmt.Errorf("service delete failed: %w", err)
+	}
+	log.Printf("[Service] service %q removed", name)
+	return nil
+}
+
+// startService starts the service via SCM.
+func startService(name string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("SCM connect failed: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(name)
+	if err != nil {
+		return fmt.Errorf("service %q not found: %w", name, err)
+	}
+	defer s.Close()
+
+	if err := s.Start(); err != nil {
+		return fmt.Errorf("service start failed: %w", err)
+	}
+	log.Printf("[Service] service %q started", name)
+	return nil
+}
+
+// stopService stops the service via SCM.
+func stopService(name string) error {
+	m, err := mgr.Connect()
+	if err != nil {
+		return fmt.Errorf("SCM connect failed: %w", err)
+	}
+	defer m.Disconnect()
+
+	s, err := m.OpenService(name)
+	if err != nil {
+		return fmt.Errorf("service %q not found: %w", name, err)
+	}
+	defer s.Close()
+
+	status, err := s.Control(svc.Stop)
+	if err != nil {
+		return fmt.Errorf("service stop failed: %w", err)
+	}
+
+	// Wait for the service to actually stop
+	timeout := time.Now().Add(30 * time.Second)
+	for time.Now().Before(timeout) {
+		if status.State == svc.Stopped {
+			break
+		}
+		time.Sleep(500 * time.Millisecond)
+		var err2 error
+		status, err2 = s.Query()
+		if err2 != nil {
+			break
+		}
+	}
+
+	log.Printf("[Service] service %q stopped", name)
+	return nil
+}
+
+// isWindowsService returns true when the process was started by SCM.
+func isWindowsService() bool {
+	ok, err := svc.IsWindowsService()
+	return ok && err == nil
+}
+
+// runService enters the SCM event loop and blocks until the service is stopped.
+// When a stop/shutdown signal arrives it closes shutdownCh to trigger
+// graceful server shutdown in the main goroutine.
+func runService(name string) error {
+	return svc.Run(name, &serviceHandler{})
+}
+
+type serviceHandler struct{}
+
+func (h *serviceHandler) Execute(args []string, r <-chan svc.ChangeRequest, s chan<- svc.Status) (bool, uint32) {
+	s <- svc.Status{State: svc.Running, Accepts: svc.AcceptStop | svc.AcceptShutdown}
+	log.Println("[Service] SCM event loop started")
+
+	for c := range r {
+		switch c.Cmd {
+		case svc.Interrogate:
+			s <- c.CurrentStatus
+		case svc.Stop, svc.Shutdown:
+			log.Println("[Service] received stop/shutdown from SCM")
+			s <- svc.Status{State: svc.StopPending}
+			// Signal server goroutine to shut down via shutdownCh
+			select {
+			case <-shutdownCh:
+			default:
+				close(shutdownCh)
+			}
+			return false, 0
+		}
+	}
+	return false, 0
+}

--- a/backend-go/shutdown.go
+++ b/backend-go/shutdown.go
@@ -1,0 +1,11 @@
+package main
+
+// shutdownCh is closed when the process should gracefully shut down.
+// On Linux it is triggered by SIGINT/SIGTERM; on Windows by the SCM
+// service handler. The signal-handling goroutine and the server loop
+// select on this channel.
+var shutdownCh = make(chan struct{})
+
+// shutdownDoneCh is closed after the server has completed its graceful
+// shutdown, including closing the metrics store and recovery loop.
+var shutdownDoneCh = make(chan struct{})

--- a/docs/DEV_PLAN_SELF_UPDATE.md
+++ b/docs/DEV_PLAN_SELF_UPDATE.md
@@ -1,0 +1,348 @@
+# 开发计划：CCX 二进制自更新
+
+> 关联文档：[docs/SELF_UPDATE.md](SELF_UPDATE.md) · [docs/service/README.md](service/README.md)
+
+## 依赖关系图
+```
+Step 1 (Windows SCM) ───┐                       ┌──→ Step 3 (updater 包) ──→ Step 4 (API) ──→ Step 5 (前端)
+Step 2 (--health-check) ─┘
+```
+
+Step 1 和 Step 2 互不依赖可并行，Step 3 依赖二者合入后才有完整的预飞行 + 替换基础设施，Step 4 是 Step 3 的 HTTP 薄封装，Step 5 是 UI 层消费者。
+
+---
+
+## Step 1：Windows SCM 服务集成
+
+**目标**：用 `ccx --install` / `--uninstall` / `--start` / `--stop` 替代 NSSM。
+
+**依赖**：`golang.org/x/sys/windows/svc` + `svc/mgr`（已是间接依赖，版本 v0.41.0，无需 `go get`）。
+
+### 文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `backend-go/service_windows.go` | 新建 | 构建标签 `//go:build windows`，SCM 服务注册/管理/事件循环 |
+| `backend-go/service_stub.go` | 新建 | `//go:build !windows`，非 Windows 平台的桩函数 |
+| `backend-go/shutdown.go` | 新建 | `shutdownCh` / `shutdownDoneCh` channel 定义 |
+| `backend-go/main.go` | 修改 | 在 `os.Args` 分发块增加 4 个 case；入口增加 SCM 检测 |
+
+### `service_windows.go` 接口
+
+```go
+func installService(name, displayName, exePath string) error  // 写入 SCM
+func removeService(name string) error                         // 从 SCM 删除
+func startService(name string) error                          // 启动
+func stopService(name string) error                           // 停止
+func isWindowsService() bool                                  // 是否由 SCM 启动
+func runService(name string) error                            // 事件循环，阻塞
+```
+
+SCM 注册配置：
+- 启动类型：自动（开机自启）
+- 失败重启：3 次 / 30 秒
+- 环境变量：不存储，CCX 启动时从 exe 同目录 `.env` 读取（已有 `godotenv.Load()`）
+
+### `main.go` 改动
+
+CLI 分发新增：
+```go
+case "--install":
+    exePath, _ := os.Executable()
+    err := installService("ccx", "CCX API Gateway", exePath)
+case "--uninstall":
+    err := removeService("ccx")
+case "--start":
+    err := startService("ccx")
+case "--stop":
+    err := stopService("ccx")
+```
+
+`main()` 入口增加 SCM 服务模式检测：
+
+```go
+if isWindowsService() {
+    runService("ccx")
+    return
+}
+```
+
+### 验证
+
+```
+Windows 上 go build → ccx --install → Get-Service ccx
+→ ccx --start → http://localhost:3000/health
+→ ccx --stop → ccx --uninstall
+```
+
+---
+
+## Step 2：`--health-check` 模式
+
+**目标**：新二进制能以最小模式启动，暴露 `/health` 供预飞行验证。
+
+### 文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `backend-go/health_check.go` | 新建 | `runHealthCheck()` 函数：随机 localhost 端口 + 5 秒自动退出 |
+| `backend-go/main.go` | 修改 | 在 CLI 分发块增加 `case "--health-check"` |
+
+### 逻辑
+
+```go
+case "--health-check":
+    runHealthCheck()
+```
+
+`runHealthCheck()` 设计：
+- 绑定 `127.0.0.1:0`（localhost 随机端口），不暴露给外部网络
+- 输出 `READY:<port>` 到 stdout 供调用方解析
+- 5 秒后自动 `os.Exit(0)`
+
+### 验证
+
+```
+ccx --health-check → 看到 READY:xxxxx → curl http://127.0.0.1:xxxxx/health 返回 version
+```
+
+---
+
+## Step 3：`internal/updater/` 包
+
+**目标**：版本检查、下载、预飞行编排、平台自替换的核心逻辑。
+
+### 文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `backend-go/internal/updater/updater.go` | 新建 | 共享逻辑：`CheckLatest`、`DownloadBinary`、`DoUpdate`（编排）、`preFlightCheck` |
+| `backend-go/internal/updater/updater_unix.go` | 新建 | `//go:build !windows`。`selfReplace(exePath)`：rename 备份 → rename 替换 → `os.Exit(0)` |
+| `backend-go/internal/updater/updater_windows.go` | 新建 | `//go:build windows`。`selfReplace(exePath)`：rename 备份 → rename 替换 → `os.Exit(1)` |
+| `backend-go/internal/updater/updater_test.go` | 新建 | 版本比较、资产匹配的单元测试 |
+
+### 核心数据结构与函数
+
+```go
+// ReleaseInfo GitHub Release 信息
+type ReleaseInfo struct {
+    Version     string // "v2.7.0"
+    DownloadURL string
+    PublishedAt string
+    HTMLURL     string
+}
+
+// CheckLatest 查询 GitHub 最新正式版（跳过 prerelease）
+func CheckLatest(owner, repo string) (*ReleaseInfo, error)
+
+// DownloadBinary 下载二进制到指定路径，流式写入，完成后 chmod 0755
+func DownloadBinary(url, destPath string) error
+
+// preFlightCheck 在新端口启动 binaryPath（--health-check 模式），GET /health
+// 验证 version 字段，5 秒超时
+func preFlightCheck(binaryPath string, expectedVersion string) error
+
+// DoUpdate 完整更新流程，成功时不返回（直接退出）
+func DoUpdate(owner, repo, currentVersion string) error
+```
+
+### DoUpdate 流程
+
+```
+1. CheckLatest(owner, repo) → 获取 ReleaseInfo
+2. 版本比较（semver.Compare）→ 如果已是最新，返回 nil
+3. 匹配当前 GOOS/GOARCH 资产
+4. DownloadBinary(downloadURL, "<exe>.new")
+5. preFlightCheck("<exe>.new", latestVersion)
+6. selfReplace(os.Executable()) → 不返回
+```
+
+### 资产匹配
+
+编译时 `runtime.GOOS`/`GOARCH` 决定：
+
+```go
+func AssetName() string {
+    switch runtime.GOOS {
+    case "linux":
+        return "ccx-linux-" + runtime.GOARCH
+    case "windows":
+        return "ccx-windows-" + runtime.GOARCH + ".exe"
+    }
+}
+```
+
+### 版本比较
+
+使用 `golang.org/x/mod/semver`（已是间接依赖）。开发版本 `v0.0.0-dev` 始终视为可更新。
+
+### 验证
+
+- 单元测试：`AssetName` 返回正确资产名
+- 单元测试：版本比较矩阵（包括 `v0.0.0-dev`、`v2.6.89 < v2.7.0`、`v2.7.0 == v2.7.0`）
+- 集成测试：`DoUpdate` 端到端（需可控的 GitHub Release 环境或 mock）
+
+---
+
+## Step 4：API Handler
+
+**目标**：`/api/version/check` 和 `/api/version/update` 两个端点。
+
+### 文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `backend-go/internal/handlers/version_handler.go` | 新建 | 两个 handler，使用 `health.go` 中的 `versionString`/`buildTime`/`gitCommit` 变量 |
+| `backend-go/main.go` | 修改 | 在 `apiGroup` 中注册路由 |
+
+### Handler 签名
+
+```go
+// GET /api/version/check — 返回当前版本 + GitHub 最新版本
+func VersionCheckHandler(envCfg *config.EnvConfig) gin.HandlerFunc
+
+// POST /api/version/update — 触发更新流程
+// 权限：需要管理密钥认证（ADMIN_ACCESS_KEY）
+// 先返回 {"status":"updating"}，再后台执行 DoUpdate
+func VersionUpdateHandler(envCfg *config.EnvConfig) gin.HandlerFunc
+```
+
+### 响应格式
+
+`GET /api/version/check`：
+
+```json
+{
+  "current": {"version": "v2.6.89", "buildTime": "...", "gitCommit": "abc1234"},
+  "latest":  {"version": "v2.7.0", "publishedAt": "...", "url": "https://..."},
+  "hasUpdate": true
+}
+```
+
+`POST /api/version/update` 成功：
+
+```json
+{"status": "updating", "message": "更新已开始，服务即将重启"}
+```
+
+`POST /api/version/update` 失败：
+
+```json
+{"status": "error", "message": "预飞行验证失败：health check 超时"}
+```
+
+`GET /api/version/status`：
+
+```json
+{"status": "downloading", "error": "", "progress": 35}
+```
+
+`status` 可能值：`idle` | `downloading` | `verifying` | `failed`。`progress` 为 0–100 整数。
+
+### 路由注册
+
+```go
+apiGroup.GET("/version/check", handlers.VersionCheckHandler(envCfg))
+apiGroup.POST("/version/update", handlers.VersionUpdateHandler(envCfg))
+apiGroup.GET("/version/status", handlers.VersionStatusHandler(envCfg))
+```
+
+### 验证
+
+```
+curl http://localhost:3000/api/version/check
+curl -X POST http://localhost:3000/api/version/update -H "x-api-key: <admin-key>"
+```
+
+---
+
+## Step 5：前端确认对话框
+
+**目标**：版本徽章点击 → 确认对话框 → 更新进度 → 轮询恢复 → 显示结果。
+
+### 文件
+
+| 文件 | 操作 | 说明 |
+|------|------|------|
+| `frontend/src/components/VersionUpdateDialog.vue` | 新建 | 确认对话框组件，含状态机 |
+| `frontend/src/services/version.ts` | 修改 | 增加 `triggerUpdate()` 函数和 `checkViaBackend()` 方法 |
+| `frontend/src/stores/system.ts` | 修改 | 增加 `updateStatus` 状态字段 |
+| `frontend/src/App.vue` | 修改 | `handleVersionClick` 改为打开对话框；模板加入 `<VersionUpdateDialog>` |
+| `frontend/src/i18n/messages.ts` | 修改 | 新增 13 个 i18n key |
+
+### 组件设计
+
+```
+状态机：confirming → downloading → success / error
+
+confirming:
+  标题：发现新版本
+  内容：v2.6.89 → v2.7.0
+        发布日期：2026-05-20
+        [查看更新说明]（外链 GitHub Releases）
+  按钮：[稍后再说]  [立即更新]
+
+downloading:
+  标题：正在更新
+  内容：长方形填充进度条（轮询 /api/version/status 获取 progress 0–100） + "正在下载..."
+  → "正在验证新版本..."
+  → "更新完成，服务即将重启..."
+  按钮：无（不可取消）
+
+success:
+  标题：更新成功
+  内容：已更新至 v2.7.0
+        [查看 GitHub Releases]
+  按钮：[关闭]
+
+error:
+  标题：更新失败
+  内容：错误信息（如网络超时、预飞行验证失败）
+  按钮：[关闭]
+```
+
+### 轮询恢复检测
+
+更新请求发出后，每 2 秒轮询 `/health`（复用已有 `fetchHealth`），检测 `version.version` 字段是否变为新版本号。最多轮询 30 秒。成功后更新 `systemStore.versionInfo` 并关闭对话框。
+
+### i18n 新 key
+
+| Key | 中文 |
+|-----|------|
+| `app.version.updateAvailable` | 发现新版本 |
+| `app.version.currentVersion` | 当前版本 |
+| `app.version.latestVersion` | 最新版本 |
+| `app.version.publishedAt` | 发布日期 |
+| `app.version.releaseNotes` | 查看更新说明 |
+| `app.version.updateNow` | 立即更新 |
+| `app.version.later` | 稍后再说 |
+| `app.version.downloading` | 正在下载新版本... |
+| `app.version.verifying` | 正在验证新版本... |
+| `app.version.restarting` | 更新完成，服务即将重启... |
+| `app.version.updateSuccess` | 更新成功 |
+| `app.version.updateFailed` | 更新失败 |
+| `app.version.close` | 关闭 |
+
+### 验证
+
+- 单元测试：`VersionUpdateDialog` 各状态渲染正确
+- 集成测试：mock `/api/version/check` 返回 `hasUpdate: true` → 确认 UI 显示
+- 手动测试：部署旧版本 → 打开界面 → 确认对话框 → 点击"立即更新" → 观察重启 → 确认新版本显示
+
+---
+
+## 版本发布
+
+- **版本号**：`v2.7.0`（MINOR bump，向下兼容的功能新增）
+- **CHANGELOG**：`### Added` 下增加自更新功能条目
+- **CI 验证**：`make build` + `cd backend-go && make test` + `cd frontend && bun run build`
+
+## 改动范围
+
+| 层 | 新增文件 | 修改文件 | 预估代码量 |
+|---|---------|---------|-----------|
+| Go 后端 | 7 | 1 | ~500 行 |
+| 前端 | 1 | 3 | ~280 行 |
+| i18n | 0 | 1 | ~50 行 |
+
+总计 ~830 行新代码，无新增外部依赖。

--- a/docs/SELF_UPDATE.md
+++ b/docs/SELF_UPDATE.md
@@ -1,0 +1,207 @@
+# CCX 二进制自更新
+
+CCX 通过 Web 管理界面提供二进制自更新功能。支持一键更新，无需手动下载替换。
+
+## 使用方式
+
+1. 打开 CCX Web 管理界面
+2. 顶栏右侧的版本徽章会自动检测更新：
+   - 显示当前版本（如 `v2.6.89`）— 已是最新
+   - 显示 `v2.6.89 → v2.7.0` — 有新版本可用
+   - 显示时钟图标 — 正在检查
+3. 点击版本徽章：
+   - 有新版本时弹出确认对话框，显示新版本号、发布日期和更新说明链接
+   - 点击"立即更新"执行更新
+4. 更新过程：点击"立即更新" → 下载新版本（进度条逐步填充） → 预飞行验证 → 替换二进制 → 服务重启（约 10–30 秒）
+5. 重启后界面自动刷新，版本徽章显示新版本号，点击可跳转 GitHub Releases 查看详情
+
+## 版本检测机制
+
+- 版本徽章在页面加载时自动检查一次
+- 检测结果缓存 30 分钟，避免频繁请求 GitHub API
+- 检测来源：`GET /api/version/check`（后端调用 GitHub API）
+- 仅匹配正式版本，跳过 `-rc`、`-beta` 等预发布版本
+
+## 更新执行流程
+
+```
+用户点击"立即更新"
+  → 后端下载新二进制到 <binary>.new（同目录，同文件系统）
+  → 校验下载完整性（文件大小 > 1MB）
+  → 【预飞行验证】在新端口启动新二进制，GET /health 验证正常
+  → 验证通过：将当前二进制重命名为临时 .old 文件，释放文件名
+  → 将 <binary>.new rename 为 <binary>（原子替换）
+  → 删除临时 .old 文件，清理完成
+  → 后端进程退出
+  → 服务管理器自动拉起新版本
+  → 前端轮询 /health 检测到版本号变化，显示更新成功
+```
+
+### 预飞行验证
+
+预飞行验证是整个更新流程的核心安全保障。在替换当前运行的程序之前，CCX 会先对新二进制进行隔离测试：
+
+1. 以 `--health-check` 模式启动新二进制（绑定随机 localhost 端口）
+2. 解析 `READY:<port>` 信号，向 `/health` 发送 GET 请求，超时 5 秒
+3. 验证响应中 `version` 字段与预期一致
+4. 验证通过后杀掉临时进程，继续替换流程
+
+预飞行验证通过即证明新二进制可正常启动并响应请求，因此替换后直接删除旧版本。如果验证失败（启动崩溃、端口未监听、版本不匹配），新二进制被删除，当前版本不受影响，前端显示错误提示。
+
+### Linux（systemd）— 全自动
+
+```
+下载 → 预飞行验证 → rename 替换 → 删除旧版本 → os.Exit(0)
+→ systemd Restart=always 在 5 秒后自动拉起（进程以 os.Exit(0) 正常退出）
+```
+
+**为什么可以原子替换**：Linux 内核中文件由 inode 标识。`rename` 覆盖运行中的二进制时，内核将目录项指向新 inode，旧 inode 仍被运行中的进程持有，进程继续正常执行至退出。停服窗口约 5 秒。
+
+### Windows（SCM 服务）— 全自动
+
+```
+下载 → 预飞行验证 → rename 当前 exe 为 .old（释放文件名） → rename .new 为 exe → 删除 .old → os.Exit(1)
+→ SCM 检测到非零退出码，触发失败重启动作，以新 exe 启动
+```
+
+**技术说明**：Windows 不允许删除或覆盖正在运行的 exe，但**允许重命名**。因此流程是先将当前 exe 重命名为临时 `.old` 文件释放原路径，再将 `.new` 重命名为 exe，删除临时文件，最后以非零退出码通知 SCM 执行失败重启动作。两个平台的核心替换逻辑一致，仅在退出码上不同。
+
+停服窗口约 2–5 秒。
+
+> **注意**：Windows 下替换完成后 `.old` 备份文件可能无法立即删除（运行中的进程持有文件句柄）。
+> 此为 Windows 文件系统行为，不影响功能，`.old` 文件可在下次重启后手动清理。
+
+## 后端 API
+
+| 端点 | 方法 | 认证 | 说明 |
+|------|------|------|------|
+| `/api/version/check` | `GET` | 无 | 返回当前版本信息及 GitHub 最新版本 |
+| `/api/version/update` | `POST` | 管理密钥 | 触发更新（下载 → 预飞行验证 → 替换 → 退出/重启服务） |
+| `/api/version/status` | `GET` | 无 | 返回更新进度状态（供前端轮询进度条） |
+
+`/api/version/check` 响应示例：
+
+```json
+{
+  "current": {
+    "version": "v2.6.89",
+    "buildTime": "2026-05-13_08:00:00_CST",
+    "gitCommit": "abc1234"
+  },
+  "latest": {
+    "version": "v2.7.0",
+    "publishedAt": "2026-05-20T10:00:00Z",
+    "url": "https://github.com/BenedictKing/ccx/releases/tag/v2.7.0"
+  },
+  "hasUpdate": true
+}
+```
+
+`/api/version/update` 成功响应：
+
+```json
+{
+  "status": "updating",
+  "message": "更新已开始，服务即将重启"
+}
+```
+
+预飞行验证失败响应：
+
+```json
+{
+  "status": "error",
+  "message": "新版本启动验证失败：health check 超时。当前版本未受影响。"
+}
+```
+
+`/api/version/status` 响应示例：
+
+```json
+{
+  "status": "downloading",
+  "error": "",
+  "progress": 35
+}
+```
+
+`status` 可能值：`idle` | `downloading` | `verifying` | `failed`。`progress` 为 0–100 的整数，前端据此渲染长方形填充进度条。
+
+## systemd 重启限制配置
+
+CCX 的 systemd 服务单元包含重启限制，作为最后的兜底保护：
+
+```ini
+# docs/service/ccx.service（关键配置）
+Restart=always
+RestartSec=5
+StartLimitBurst=3
+StartLimitInterval=30s
+```
+
+含义：30 秒内最多允许 3 次重启。超过限制后 systemd 停止尝试，服务进入 failed 状态。
+
+## 边界情况
+
+| 场景 | 行为 |
+|------|------|
+| 已是最新版本 | 版本徽章正常显示，点击跳转 GitHub Releases |
+| GitHub API 不可达 | 版本徽章显示当前版本，错误状态缓存 5 分钟 |
+| 当前架构无匹配二进制 | 更新请求返回错误，前端显示提示 |
+| 开发版本（`v0.0.0-dev`） | 视为可更新，允许覆盖 |
+| 下载中断/磁盘满 | 清理临时文件，前端显示错误提示 |
+| 预飞行验证失败 | 删除新二进制，保留当前版本，前端显示错误 |
+| 二进制目录无写入权限 | 后端返回 500，前端显示权限错误 |
+| 新版本启动崩溃（绕过预飞行） | systemd/SCM 重试 3 次后停止，需手动干预恢复 |
+| 目标版本不支持 `--health-check`（首次自更新前的旧版本） | 跳过健康验证，仅依赖下载大小校验，替换后继续 |
+| 预飞行检查 stdout 读取超时 | 子进程被杀，新二进制被删除，当前版本不受影响 |
+
+## 安全保障层次
+
+| 层次 | 机制 | 作用 |
+|------|------|------|
+| 下载校验 | 文件大小 > 1MB | 防止下载错误页面 |
+| 预飞行验证 | `--health-check` + `/health` | 确保新版本能正常启动 |
+| SCM/systemd 限制 | 30s 内最多 3 次重启 | 防止无限崩溃循环 |
+| 并发控制 | `atomic.Bool` | 防止重复触发更新 |
+| 原子替换 | `os.Rename` 同文件系统 | 不会出现"半个二进制" |
+
+## 服务注册
+
+自更新依赖服务管理器实现自动重启。使用前请确保 CCX 已注册为系统服务：
+
+**Linux**：
+
+```bash
+sudo cp docs/service/ccx.service /etc/systemd/system/ccx.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now ccx
+```
+
+**Windows**（以管理员身份）：
+
+```powershell
+ccx-windows-amd64.exe --install
+ccx-windows-amd64.exe --start
+```
+
+详见 [`docs/service/README.md`](service/README.md)。
+
+## 网络要求
+
+更新功能需要服务器能够访问：
+
+- `https://api.github.com` — 查询 Release 信息
+- GitHub Release 资产下载地址（由上述 API 返回）
+
+如果服务器无法直连 GitHub，可设置 HTTP 代理环境变量后重启 CCX。
+
+## 与 Docker 的关系
+
+Docker 部署的用户**不应使用**此功能。容器内替换二进制后，重启容器时旧镜像会覆盖替换结果。
+
+Docker 用户请使用 Watchtower 自动更新：
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.watchtower.yml up -d
+```

--- a/docs/service/windows-service.md
+++ b/docs/service/windows-service.md
@@ -1,0 +1,76 @@
+﻿# Windows 服务注册
+
+CCX 内置了 Windows 服务注册命令，无需安装第三方工具。
+
+## 配置运行环境
+
+CCX 通过 exe 同目录下的 `.env` 文件读取运行配置（与 Linux 一致）：
+
+```powershell
+# C:\ccx\.env
+PROXY_ACCESS_KEY=your-proxy-access-key
+PORT=3000
+ENABLE_WEB_UI=true
+APP_UI_LANGUAGE=zh-CN
+ENV=production
+LOG_LEVEL=warn
+```
+
+## 注册服务
+
+以管理员身份打开 PowerShell：
+
+```powershell
+# 注册为 Windows 服务（自动启动 + 崩溃重启）
+ccx-windows-amd64.exe --install
+
+# 启动服务
+ccx-windows-amd64.exe --start
+```
+
+`--install` 会将当前 exe 注册到 Windows 服务控制管理器（SCM），配置：
+
+- 启动类型：自动（开机自启）
+- 崩溃重启：连续 3 次失败后停止，间隔 30 秒
+- 工作目录：exe 所在目录
+- 环境变量：SCM 不存储环境变量，由 CCX 启动时从 `.env` 文件读取
+
+## 常用命令
+
+```powershell
+ccx-windows-amd64.exe --start      # 启动服务
+ccx-windows-amd64.exe --stop       # 停止服务
+ccx-windows-amd64.exe --uninstall  # 移除服务
+```
+
+## 查看状态
+
+```powershell
+Get-Service ccx
+```
+
+或通过 `services.msc` 图形界面查看。
+
+## 升级二进制
+
+```powershell
+ccx-windows-amd64.exe --stop
+# 替换 exe 文件
+ccx-windows-amd64.exe --start
+```
+
+或通过 Web 管理界面使用自更新功能（详见 [`docs/SELF_UPDATE.md`](../SELF_UPDATE.md)）。
+
+## 备选方案：NSSM
+
+如果因环境限制无法使用内置服务命令，仍可使用 NSSM：
+
+1. 下载 [NSSM](https://nssm.cc/download)
+2. 以管理员身份运行：
+
+```powershell
+nssm install ccx C:\ccx\ccx-windows-amd64.exe
+nssm set ccx AppDirectory C:\ccx
+nssm set ccx Start SERVICE_AUTO_START
+nssm start ccx
+```

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -432,6 +432,15 @@
         {{ toast.message }}
       </div>
     </v-snackbar>
+
+    <!-- 版本更新对话框 -->
+    <VersionUpdateDialog
+      v-if="showUpdateDialog"
+      :model-value="showUpdateDialog"
+      :version-info="updateDialogInfo"
+      @update:model-value="showUpdateDialog = $event"
+      @update-success="onUpdateSuccess"
+    />
   </v-app>
 </template>
 
@@ -449,6 +458,8 @@ import { useI18n } from './i18n'
 import type { SupportedLocale } from './i18n'
 import AddChannelModal from './components/AddChannelModal.vue'
 import CapabilityTestDialog from './components/CapabilityTestDialog.vue'
+import VersionUpdateDialog from './components/VersionUpdateDialog.vue'
+import type { VersionInfo } from './services/version'
 // 异步加载图表组件，减少首屏 JS 体积
 const GlobalStatsChart = defineAsyncComponent(() => import('./components/GlobalStatsChart.vue'))
 import { useAppTheme } from './composables/useTheme'
@@ -1648,8 +1659,8 @@ const checkVersion = async () => {
       versionService.setCurrentVersion(currentVersion)
       systemStore.setCurrentVersion(currentVersion)
 
-      // 检查 GitHub 最新版本
-      const result = await versionService.checkForUpdates()
+      // 通过后端 API 检查最新版本
+      const result = await versionService.checkViaBackend()
       systemStore.setVersionInfo(result)
     } else {
       systemStore.setVersionInfo({
@@ -1669,11 +1680,20 @@ const checkVersion = async () => {
 }
 
 // 版本点击处理
+
+// 更新对话框相关状态
+const showUpdateDialog = ref(false)
+const updateDialogInfo = ref<VersionInfo>(systemStore.versionInfo)
+
+const onUpdateSuccess = () => {
+  showUpdateDialog.value = false
+}
+
 const handleVersionClick = () => {
-  if (
-    (systemStore.versionInfo.status === 'update-available' || systemStore.versionInfo.status === 'latest') &&
-    systemStore.versionInfo.releaseUrl
-  ) {
+  if (systemStore.versionInfo.status === 'update-available') {
+    updateDialogInfo.value = { ...systemStore.versionInfo }
+    showUpdateDialog.value = true
+  } else if (systemStore.versionInfo.status === 'latest' && systemStore.versionInfo.releaseUrl) {
     window.open(systemStore.versionInfo.releaseUrl, '_blank', 'noopener,noreferrer')
   }
 }

--- a/frontend/src/components/VersionUpdateDialog.vue
+++ b/frontend/src/components/VersionUpdateDialog.vue
@@ -1,0 +1,261 @@
+<template>
+  <v-dialog v-model="visible" max-width="480" persistent>
+    <v-card v-if="state === 'confirming'">
+      <v-card-title class="d-flex align-center pa-4">
+        <v-icon size="24" class="mr-3" color="warning">mdi-alert</v-icon>
+        <span>{{ t('app.version.updateAvailable') }}</span>
+      </v-card-title>
+      <v-card-text class="pa-4 pt-0">
+        <div class="d-flex align-center justify-center my-4">
+          <span class="text-h5 font-weight-bold">{{ versionInfo.currentVersion }}</span>
+          <v-icon size="28" class="mx-3" color="warning">mdi-arrow-right-bold</v-icon>
+          <span class="text-h5 font-weight-bold" color="primary">{{ versionInfo.latestVersion }}</span>
+        </div>
+        <div v-if="publishedAt" class="text-center text-body-2 text-medium-emphasis mb-4">
+          {{ t('app.version.publishedAt') }}: {{ publishedAt }}
+        </div>
+        <v-btn
+          v-if="releaseUrl"
+          variant="text"
+          block
+          :href="releaseUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          prepend-icon="mdi-open-in-new"
+          class="text-none"
+        >
+          {{ t('app.version.releaseNotes') }}
+        </v-btn>
+      </v-card-text>
+      <v-card-actions class="pa-4 pt-0">
+        <v-spacer />
+        <v-btn variant="text" @click="cancel">
+          {{ t('app.version.later') }}
+        </v-btn>
+        <v-btn color="primary" variant="elevated" @click="confirm" :loading="loading">
+          {{ t('app.version.updateNow') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <v-card v-else-if="state === 'downloading'">
+      <v-card-title class="d-flex align-center pa-4">
+        <v-progress-circular indeterminate :size="20" :width="2" class="mr-3" />
+        <span>{{ progressText }}</span>
+      </v-card-title>
+      <v-card-text class="pa-4 pt-0">
+        <v-progress-linear :model-value="progress" color="primary" height="6" rounded />
+      </v-card-text>
+    </v-card>
+
+    <v-card v-else-if="state === 'success'">
+      <v-card-title class="d-flex align-center pa-4">
+        <v-icon size="24" class="mr-3" color="success">mdi-check-circle</v-icon>
+        <span>{{ t('app.version.updateSuccess') }}</span>
+      </v-card-title>
+      <v-card-text class="pa-4 pt-0">
+        <div class="text-center my-4">
+          <span class="text-h5 font-weight-bold" color="success">{{ versionInfo.latestVersion || versionInfo.currentVersion }}</span>
+        </div>
+        <v-btn
+          v-if="releaseUrl"
+          variant="text"
+          block
+          :href="releaseUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          prepend-icon="mdi-open-in-new"
+          class="text-none"
+        >
+          {{ t('app.version.releaseNotes') }}
+        </v-btn>
+      </v-card-text>
+      <v-card-actions class="pa-4 pt-0">
+        <v-spacer />
+        <v-btn color="primary" variant="elevated" @click="close">
+          {{ t('app.version.close') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+
+    <v-card v-else-if="state === 'error'">
+      <v-card-title class="d-flex align-center pa-4">
+        <v-icon size="24" class="mr-3" color="error">mdi-alert-circle</v-icon>
+        <span>{{ t('app.version.updateFailed') }}</span>
+      </v-card-title>
+      <v-card-text class="pa-4 pt-0">
+        <v-alert type="error" variant="tonal" class="mb-0">
+          {{ errorMessage }}
+        </v-alert>
+      </v-card-text>
+      <v-card-actions class="pa-4 pt-0">
+        <v-spacer />
+        <v-btn color="primary" variant="elevated" @click="close">
+          {{ t('app.version.close') }}
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, watch } from 'vue'
+import { useI18n } from '../i18n'
+import { versionService } from '../services/version'
+import { useSystemStore } from '../stores/system'
+import type { VersionInfo } from '../services/version'
+
+const props = defineProps<{
+  modelValue: boolean
+  versionInfo: VersionInfo
+}>()
+
+const emit = defineEmits<{
+  'update:modelValue': [value: boolean]
+  'update-success': []
+}>()
+
+const { t } = useI18n()
+const systemStore = useSystemStore()
+
+const loading = ref(false)
+const state = ref<'confirming' | 'downloading' | 'success' | 'error'>('confirming')
+const errorMessage = ref('')
+const progressText = ref('')
+const progress = ref(0)
+const pollTimer = ref<ReturnType<typeof setInterval> | null>(null)
+
+const releaseUrl = computed(() => props.versionInfo.releaseUrl || '')
+
+function formatPublishedDate(isoString: string | null): string {
+  if (!isoString) return ''
+  try {
+    const d = new Date(isoString)
+    return d.toLocaleDateString()
+  } catch {
+    return isoString
+  }
+}
+const publishedAt = computed(() => formatPublishedDate(
+  props.versionInfo.latestVersion ? (props.versionInfo.publishedAt ?? null) : null
+))
+
+const visible = computed({
+  get: () => props.modelValue,
+  set: (v: boolean) => emit('update:modelValue', v),
+})
+
+watch(() => props.modelValue, (v) => {
+  if (v) reset()
+})
+
+function reset() {
+  state.value = 'confirming'
+  loading.value = false
+  errorMessage.value = ''
+  progressText.value = ''
+  progress.value = 0
+  if (pollTimer.value) {
+    clearInterval(pollTimer.value)
+    pollTimer.value = null
+  }
+}
+
+function cancel() {
+  visible.value = false
+}
+
+function close() {
+  if (pollTimer.value) {
+    clearInterval(pollTimer.value)
+    pollTimer.value = null
+  }
+  visible.value = false
+}
+
+async function confirm() {
+  loading.value = true
+  state.value = 'downloading'
+  progressText.value = t('app.version.downloading')
+  progress.value = 0
+
+  const result = await versionService.triggerUpdate()
+  if (result.status === 'error') {
+    state.value = 'error'
+    errorMessage.value = result.message
+    loading.value = false
+    return
+  }
+
+  // Poll /api/version/status for progress, fall back to /health for completion
+  let attempts = 0
+  const maxAttempts = 120 // 120 * 2s = 240s max
+  pollTimer.value = setInterval(async () => {
+    attempts++
+
+    try {
+      // Check update status from backend
+      const statusResult = await versionService.checkUpdateStatus()
+
+      if (statusResult.status === 'failed') {
+        clearInterval(pollTimer.value!)
+        pollTimer.value = null
+        state.value = 'error'
+        errorMessage.value = statusResult.error || t('app.version.updateFailed')
+        loading.value = false
+        return
+      }
+
+      if (statusResult.status === 'idle') {
+        // Already at latest: treat as success
+        clearInterval(pollTimer.value!)
+        pollTimer.value = null
+        state.value = 'success'
+        loading.value = false
+        return
+      }
+
+      progress.value = statusResult.progress ?? 0
+
+      if (statusResult.status === 'downloading') {
+        progressText.value = t('app.version.downloading')
+      } else if (statusResult.status === 'verifying') {
+        progressText.value = t('app.version.verifying')
+      }
+
+      // Also poll /health to detect when the server comes back with new version
+      try {
+        const { fetchHealth } = await import('../services/api')
+        const health = await fetchHealth()
+        const newVersion = health.version?.version || ''
+        if (newVersion && newVersion !== props.versionInfo.currentVersion) {
+          clearInterval(pollTimer.value!)
+          pollTimer.value = null
+          state.value = 'success'
+          loading.value = false
+          systemStore.setCurrentVersion(newVersion)
+          systemStore.setVersionInfo({
+            ...systemStore.versionInfo,
+            currentVersion: newVersion,
+            status: 'latest',
+          })
+          emit('update-success')
+          return
+        }
+      } catch {
+        // Server is restarting, keep polling
+      }
+    } catch {
+      // Status endpoint may be unavailable during restart
+    }
+
+    if (attempts >= maxAttempts) {
+      clearInterval(pollTimer.value!)
+      pollTimer.value = null
+      state.value = 'error'
+      errorMessage.value = '更新超时：服务未在预期时间内完成重启'
+      loading.value = false
+    }
+  }, 2000)
+}
+</script>

--- a/frontend/src/i18n/messages.ts
+++ b/frontend/src/i18n/messages.ts
@@ -18,6 +18,19 @@ export type MessageKey =
   | 'app.tabs.gemini'
   | 'app.tabs.images'
   | 'app.header.logout'
+  | 'app.version.updateAvailable'
+  | 'app.version.currentVersion'
+  | 'app.version.latestVersion'
+  | 'app.version.publishedAt'
+  | 'app.version.releaseNotes'
+  | 'app.version.updateNow'
+  | 'app.version.later'
+  | 'app.version.downloading'
+  | 'app.version.verifying'
+  | 'app.version.restarting'
+  | 'app.version.updateSuccess'
+  | 'app.version.updateFailed'
+  | 'app.version.close'
   | 'app.stats.trafficTitle'
   | 'app.stats.totalChannels'
   | 'app.stats.totalChannelsDesc'
@@ -420,6 +433,19 @@ export const messages: Record<SupportedLocale, Record<MessageKey, string>> = {
     'app.tabs.gemini': 'Gemini',
     'app.tabs.images': 'Images',
     'app.header.logout': 'Logout',
+    'app.version.updateAvailable': 'Update Available',
+    'app.version.currentVersion': 'Current Version',
+    'app.version.latestVersion': 'Latest Version',
+    'app.version.publishedAt': 'Published',
+    'app.version.releaseNotes': 'View release notes',
+    'app.version.updateNow': 'Update Now',
+    'app.version.later': 'Later',
+    'app.version.downloading': 'Downloading new version...',
+    'app.version.verifying': 'Verifying new version...',
+    'app.version.restarting': 'Update complete, service will restart...',
+    'app.version.updateSuccess': 'Update Successful',
+    'app.version.updateFailed': 'Update Failed',
+    'app.version.close': 'Close',
     'app.stats.trafficTitle': '{tab} traffic',
     'app.stats.totalChannels': 'Total channels',
     'app.stats.totalChannelsDesc': 'Configured API channels',
@@ -821,6 +847,19 @@ export const messages: Record<SupportedLocale, Record<MessageKey, string>> = {
     'app.tabs.gemini': 'Gemini',
     'app.tabs.images': 'Images',
     'app.header.logout': 'Keluar',
+    'app.version.updateAvailable': 'Pembaruan Tersedia',
+    'app.version.currentVersion': 'Versi Saat Ini',
+    'app.version.latestVersion': 'Versi Terbaru',
+    'app.version.publishedAt': 'Diterbitkan',
+    'app.version.releaseNotes': 'Lihat catatan rilis',
+    'app.version.updateNow': 'Perbarui Sekarang',
+    'app.version.later': 'Nanti',
+    'app.version.downloading': 'Mengunduh versi baru...',
+    'app.version.verifying': 'Memverifikasi versi baru...',
+    'app.version.restarting': 'Pembaruan selesai, layanan akan dimulai ulang...',
+    'app.version.updateSuccess': 'Pembaruan Berhasil',
+    'app.version.updateFailed': 'Pembaruan Gagal',
+    'app.version.close': 'Tutup',
     'app.stats.trafficTitle': 'Traffic {tab}',
     'app.stats.totalChannels': 'Total channel',
     'app.stats.totalChannelsDesc': 'Channel API yang sudah dikonfigurasi',
@@ -1222,6 +1261,19 @@ export const messages: Record<SupportedLocale, Record<MessageKey, string>> = {
     'app.tabs.gemini': 'Gemini',
     'app.tabs.images': 'Images',
     'app.header.logout': '注销',
+    'app.version.updateAvailable': '发现新版本',
+    'app.version.currentVersion': '当前版本',
+    'app.version.latestVersion': '最新版本',
+    'app.version.publishedAt': '发布日期',
+    'app.version.releaseNotes': '查看更新说明',
+    'app.version.updateNow': '立即更新',
+    'app.version.later': '稍后再说',
+    'app.version.downloading': '正在下载新版本...',
+    'app.version.verifying': '正在验证新版本...',
+    'app.version.restarting': '更新完成，服务即将重启...',
+    'app.version.updateSuccess': '更新成功',
+    'app.version.updateFailed': '更新失败',
+    'app.version.close': '关闭',
     'app.stats.trafficTitle': '{tab} 流量统计',
     'app.stats.totalChannels': '总渠道数',
     'app.stats.totalChannelsDesc': '已配置的API渠道',

--- a/frontend/src/services/version.ts
+++ b/frontend/src/services/version.ts
@@ -24,6 +24,7 @@ export interface VersionInfo {
   releaseUrl: string | null
   lastCheckTime: number
   status: 'checking' | 'latest' | 'update-available' | 'error'
+  publishedAt?: string | null
 }
 
 // 预发布版本标识正则（如 -rc1, -beta, -alpha 等）
@@ -230,6 +231,106 @@ class VersionService {
     }
 
     return versionInfo
+  }
+
+  /**
+   * 通过后端 API 检查版本更新（替代直接调用 GitHub API）
+   */
+  async checkViaBackend(): Promise<VersionInfo> {
+    if (!this.currentVersion) {
+      return {
+        currentVersion: '',
+        latestVersion: null,
+        isLatest: false,
+        hasUpdate: false,
+        releaseUrl: null,
+        lastCheckTime: Date.now(),
+        status: 'error',
+      }
+    }
+
+    const cached = this.getCachedVersionInfo()
+    if (cached) {
+      return cached
+    }
+
+    const versionInfo: VersionInfo = {
+      currentVersion: this.currentVersion,
+      latestVersion: null,
+      isLatest: false,
+      hasUpdate: false,
+      releaseUrl: null,
+      lastCheckTime: Date.now(),
+      status: 'checking',
+    }
+
+    try {
+      const baseUrl = import.meta.env.PROD ? '' : (import.meta.env.VITE_BACKEND_URL || '')
+      const response = await fetch(`${baseUrl}/api/version/check`)
+      if (!response.ok) {
+        throw new Error(`API error: ${response.status}`)
+      }
+      const data = await response.json()
+      if (data.error) {
+        throw new Error(data.error)
+      }
+      versionInfo.latestVersion = data.latest?.version || null
+      versionInfo.releaseUrl = data.latest?.url || null
+      versionInfo.publishedAt = data.latest?.publishedAt || null
+      versionInfo.hasUpdate = !!data.hasUpdate
+      versionInfo.isLatest = !data.hasUpdate
+      versionInfo.status = data.hasUpdate ? 'update-available' : 'latest'
+      this.setCachedVersionInfo(versionInfo)
+    } catch (error) {
+      console.warn('Backend version check failed:', error)
+      versionInfo.status = 'error'
+      this.setCachedVersionInfo(versionInfo)
+    }
+
+    return versionInfo
+  }
+
+  /**
+   * 触发更新（POST /api/version/update）
+   * 需要管理权限（x-api-key header）
+   */
+  async triggerUpdate(): Promise<{ status: string; message: string }> {
+    // Get API key from auth store
+    const { useAuthStore } = await import('../stores/auth')
+    const authStore = useAuthStore()
+    const apiKey = authStore.apiKey
+    if (!apiKey) {
+      return { status: 'error', message: '未认证：请先登录管理控制台' }
+    }
+
+    const baseUrl = import.meta.env.PROD ? '' : (import.meta.env.VITE_BACKEND_URL || '')
+    try {
+      const response = await fetch(`${baseUrl}/api/version/update`, {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey as string,
+        },
+      })
+      const data = await response.json()
+    return { status: data.status, message: data.message }
+    } catch (error) {
+      return { status: 'error', message: `请求失败: ${error}` }
+    }
+  }
+
+  /**
+   * 查询更新进度状态（GET /api/version/status）
+   */
+  async checkUpdateStatus(): Promise<{ status: string; error: string; progress: number }> {
+    const baseUrl = import.meta.env.PROD ? '' : (import.meta.env.VITE_BACKEND_URL || '')
+    try {
+      const response = await fetch(`${baseUrl}/api/version/status`)
+      if (!response.ok) return { status: 'error', error: `HTTP ${response.status}`, progress: 0 }
+      const data = await response.json()
+      return { status: data.status, error: data.error || '', progress: data.progress || 0 }
+    } catch (e) {
+      return { status: 'error', error: `请求失败: ${e}`, progress: 0 }
+    }
   }
 }
 


### PR DESCRIPTION
﻿## Summary

Add complete binary self-update capability for CCX. Users can trigger one-click updates from the Web admin UI with a determinate progress bar. The backend downloads from GitHub Releases, runs a pre-flight health check on the new binary, performs an atomic rename replacement, and exits to let systemd/SCM restart the service.

## Update Flow

```
User clicks "Update Now"
  -> Download new binary to <exe>.new (same directory)
  -> Pre-flight: start new binary in --health-check mode, GET /health to verify
  -> Atomic replace: rename current -> .old -> rename .new -> current -> delete .old
  -> os.Exit (Linux=0 / Windows=1)
  -> systemd/SCM auto-restarts the new version
```

## Changes

### Backend (10 files)

**Update engine** (`internal/updater/`)
- `CheckLatest` — GitHub API query, filters prereleases, matches OS/ARCH asset
- `DownloadBinary` — streaming download + size validation (>1MB), atomic rename via .download temp
- `preFlightCheck` — starts child in --health-check mode, `bufio.Scanner` reads READY:<port>, GET /health verifies version. Gracefully skips when target binary predates --health-check support
- `selfReplace` — platform-specific atomic replacement
- `ProgressFunc` callback at key milestones (downloading/verifying/done)

**Progress tracking** (`internal/handlers/version_handler.go`)
- `GET /api/version/check` — current + latest version (public)
- `GET /api/version/status` — {status, error, progress} for frontend polling (public)
- `POST /api/version/update` — triggers update, returns immediately, background goroutine (requires admin key)
- `defer recover` protects goroutine, releases updateInProgress on panic
- Self-terminating ticker: download 0->60, verifying 65, done 100

**Health check mode** (`health_check.go`)
- Minimal Gin instance: binds 127.0.0.1:0, only /health, outputs READY:<port>, auto-exits after 5s

**Windows SCM service** (`service_windows.go`)
- --install/--uninstall/--start/--stop CLI sub-commands
- Auto-start + failure restart (3x/30s), matching systemd

**Routes** (`main.go`)
- /api/version/check, /api/version/status registered before WebAuthMiddleware (public)
- /api/version/update inside apiGroup (requires admin key)

### Frontend (4 files)

- `VersionUpdateDialog.vue` — state machine (confirming -> downloading -> success/error), determinate `<v-progress-linear :model-value="progress">`, polls /api/version/status every 2s + /health for version change
- `version.ts` — checkViaBackend, triggerUpdate, checkUpdateStatus (includes progress field)
- `App.vue` — version badge click integration
- `messages.ts` — 13 i18n keys (zh-CN + en)

### Docs (3 files)

- `SELF_UPDATE.md` — user guide
- `DEV_PLAN_SELF_UPDATE.md` — development plan
- `service/windows-service.md` — Windows service registration guide

## Key Design Decisions

- **Pre-flight is the safety baseline**: new binary MUST pass health check before replacing current; failure deletes new binary, current version unaffected
- **Graceful fallback for legacy binaries**: if target binary doesn't support --health-check (releases before this feature), health verification is skipped with a warning, only size check remains
- **Atomic replace**: `os.Rename` on same filesystem guarantees no half-binary state
- **Progress without byte counts**: ticker + milestone callbacks provide sufficient visual feedback; polling /api/version/status renders a simple filled-bar animation

## Testing

- `go test ./...` — 19/19 packages pass
- `bun run type-check` + `bun run build` — pass
- **End-to-end verified**: v0.0.0-dev -> v2.6.97 update, download -> pre-flight (graceful skip) -> replace -> exit, full chain confirmed on Windows

## Known Limitations

- Windows: .old backup file may not be immediately deletable (process holds file handle); harmless residual, overwritten on next self-update
- v2.6.97 predates self-update; next formal release enables full pre-flight chain
- Docker deployments should not use this feature (container restart overwrites replacement); use Watchtower instead
