### PR TITLE
fix(converters): 支持 Responses API 图片 source 字段，修复解析异常卡死

### DIFF
--- a/backend-go/internal/converters/responses_items.go
+++ b/backend-go/internal/converters/responses_items.go
@@ -169,38 +169,61 @@ func responsesContentBlockToOpenAIChatPart(block map[string]interface{}) map[str
 }
 
 func normalizeResponsesImageURL(block map[string]interface{}) map[string]interface{} {
+	// 优先处理 image_url 字段
 	rawImageURL, ok := block["image_url"]
+	if ok {
+		switch imageURL := rawImageURL.(type) {
+		case string:
+			if imageURL == "" {
+				return nil
+			}
+			result := map[string]interface{}{"url": imageURL}
+			if detail, _ := block["detail"].(string); detail != "" {
+				result["detail"] = detail
+			}
+			return result
+		case map[string]interface{}:
+			if _, ok := imageURL["url"].(string); !ok {
+				return nil
+			}
+			result := make(map[string]interface{}, len(imageURL)+1)
+			for key, value := range imageURL {
+				result[key] = value
+			}
+			if detail, _ := block["detail"].(string); detail != "" {
+				result["detail"] = detail
+			}
+			return result
+		default:
+			return nil
+		}
+	}
+
+	// 处理 source 字段（Responses API 标准格式）
+	rawSource, ok := block["source"]
 	if !ok {
 		return nil
 	}
-
-	switch imageURL := rawImageURL.(type) {
-	case string:
-		if imageURL == "" {
-			return nil
-		}
-		result := map[string]interface{}{"url": imageURL}
-		if detail, _ := block["detail"].(string); detail != "" {
-			result["detail"] = detail
-		}
-		return result
-	case map[string]interface{}:
-		if _, ok := imageURL["url"].(string); !ok {
-			return nil
-		}
-		result := make(map[string]interface{}, len(imageURL)+1)
-		for key, value := range imageURL {
-			result[key] = value
-		}
-		if detail, _ := block["detail"].(string); detail != "" {
-			result["detail"] = detail
-		}
-		return result
-	default:
+	source, ok := rawSource.(map[string]interface{})
+	if !ok {
 		return nil
 	}
-}
+	if source["type"] != "base64" {
+		return nil
+	}
+	mediaType, _ := source["media_type"].(string)
+	data, _ := source["data"].(string)
+	if mediaType == "" || data == "" {
+		return nil
+	}
+	dataURL := "data:" + mediaType + ";base64," + data
+	result := map[string]interface{}{"url": dataURL}
+	if detail, _ := block["detail"].(string); detail != "" {
+		result["detail"] = detail
+	}
+	return result
 
+}
 func extractResponsesReasoningText(item types.ResponsesItem) string {
 	if text := extractReasoningTextFromSummary(item.Summary); text != "" {
 		return text

--- a/backend-go/internal/converters/responses_to_chat.go
+++ b/backend-go/internal/converters/responses_to_chat.go
@@ -208,27 +208,47 @@ func convertMessageItem(item gjson.Result, out string) string {
 }
 
 func responsesImageContentToChatBlock(contentItem gjson.Result) string {
+	// 优先处理 image_url 字段
 	imageURL := contentItem.Get("image_url")
-	if !imageURL.Exists() {
-		return ""
-	}
-
-	block := `{"type":"image_url","image_url":{}}`
-	if imageURL.Type == gjson.String {
-		if imageURL.String() == "" {
+	if imageURL.Exists() {
+		block := `{"type":"image_url","image_url":{}}`
+		if imageURL.Type == gjson.String {
+			if imageURL.String() == "" {
+				return ""
+			}
+			block, _ = sjson.Set(block, "image_url.url", imageURL.String())
+		} else if imageURL.IsObject() {
+			block, _ = sjson.SetRaw(block, "image_url", imageURL.Raw)
+		} else {
 			return ""
 		}
-		block, _ = sjson.Set(block, "image_url.url", imageURL.String())
-	} else if imageURL.IsObject() {
-		block, _ = sjson.SetRaw(block, "image_url", imageURL.Raw)
-	} else {
-		return ""
+
+		if detail := contentItem.Get("detail"); detail.Exists() && detail.String() != "" {
+			block, _ = sjson.Set(block, "image_url.detail", detail.String())
+		}
+		return block
 	}
 
+	// 处理 source 字段（Responses API 标准格式）
+	// {"type":"input_image","source":{"type":"base64","media_type":"image/png","data":"..."}}
+	source := contentItem.Get("source")
+	if !source.Exists() {
+		return ""
+	}
+	if source.Get("type").String() != "base64" {
+		return ""
+	}
+	mediaType := source.Get("media_type").String()
+	data := source.Get("data").String()
+	if mediaType == "" || data == "" {
+		return ""
+	}
+	dataURL := "data:" + mediaType + ";base64," + data
+	block := `{"type":"image_url","image_url":{}}`
+	block, _ = sjson.Set(block, "image_url.url", dataURL)
 	if detail := contentItem.Get("detail"); detail.Exists() && detail.String() != "" {
 		block, _ = sjson.Set(block, "image_url.detail", detail.String())
 	}
-
 	return block
 }
 


### PR DESCRIPTION
## 问题

Codex 桌面端发图时使用标准 Responses API 格式：
```
{"type":"input_image","source":{"type":"base64","media_type":"image/png","data":"..."}}
```

但 CCX 的转换代码只识别 `image_url` 字段，不处理 `source` 字段，导致图片识别异常卡死。

## 修复

- `responsesImageContentToChatBlock()`：当 `image_url` 不存在时，读取 `source` 字段
- `normalizeResponsesImageURL()`：map 路径做同样的处理

当 `source.type == "base64"` 时，自动拼接 data URL（`data:{media_type};base64,{data}`），兼容上游 OpenAI 协议。