### PR TITLE
fix: Responses单渠道模式下未追踪对话导致驾驶舱不显示数据

### DIFF
--- a/backend-go/internal/handlers/responses/handler.go
+++ b/backend-go/internal/handlers/responses/handler.go
@@ -76,7 +76,7 @@ func Handler(
 		if isMultiChannel {
 			handleMultiChannel(c, envCfg, cfgManager, channelScheduler, sessionManager, bodyBytes, responsesReq, userID, startTime)
 		} else {
-			handleSingleChannel(c, envCfg, cfgManager, channelScheduler, sessionManager, bodyBytes, responsesReq, startTime)
+			handleSingleChannel(c, envCfg, cfgManager, channelScheduler, sessionManager, bodyBytes, userID, responsesReq, startTime)
 		}
 	})
 }
@@ -191,6 +191,7 @@ func handleSingleChannel(
 	channelScheduler *scheduler.ChannelScheduler,
 	sessionManager *session.SessionManager,
 	bodyBytes []byte,
+	userID string,
 	responsesReq types.ResponsesRequest,
 	startTime time.Time,
 ) {
@@ -218,7 +219,7 @@ func handleSingleChannel(
 
 	urlResults := common.BuildDefaultURLResults(baseURLs)
 
-	handled, _, _, lastFailoverError, _, lastError := common.TryUpstreamWithAllKeys(
+	handled, successKey, _, lastFailoverError, _, lastError := common.TryUpstreamWithAllKeys(
 		c,
 		envCfg,
 		cfgManager,
@@ -257,6 +258,32 @@ func handleSingleChannel(
 		channelIndex,
 		channelScheduler.GetChannelLogStore(scheduler.ChannelKindResponses),
 	)
+
+	// 追踪对话（驾驶舱显示）
+	if handled && successKey != "" {
+		lastUserMsg, _ := c.Get("lastUserMessage")
+		lastUserMsgStr, _ := lastUserMsg.(string)
+		userMsgCount, _ := c.Get("userMessageCount")
+		userMsgCountInt, _ := userMsgCount.(int)
+
+		if lastUserMsgStr != "" || userMsgCountInt > 0 {
+			channelName := ""
+			if upstream != nil {
+				channelName = upstream.Name
+			}
+			channelScheduler.TrackConversation(
+				scheduler.ChannelKindResponses,
+				userID,
+				responsesReq.Model,
+				channelIndex,
+				channelName,
+				"",
+				lastUserMsgStr,
+				userMsgCountInt,
+			)
+		}
+	}
+
 	if handled {
 		return
 	}


### PR DESCRIPTION
## 问题

Responses API 在单渠道模式下（仅配置 1 个渠道时），`handleSingleChannel` 缺少对话追踪逻辑，导致驾驶舱（`/conversations`）始终不显示数据。

## 修复

- 给 `handleSingleChannel` 新增 `userID` 参数传递
- 捕获 `successKey` 判断请求是否真正成功
- 成功后调用 `TrackConversation()` 写入对话追踪，与多渠道 `handleMultiChannel` 行为保持一致

## 验证

修复后测试通过：向 Responses API 发请求后，`/api/conversations` 正确返回对话记录，驾驶舱正常显示。