### PR TITLE
fix(converters): Responses → Claude 链路缺少 max_tokens 默认值

### DIFF
--- a/backend-go/internal/converters/claude_converter.go
+++ b/backend-go/internal/converters/claude_converter.go
@@ -33,6 +33,8 @@ func (c *ClaudeConverter) ToProviderRequest(sess *session.Session, req *types.Re
 	// 复制其他参数
 	if req.MaxTokens > 0 {
 		claudeReq["max_tokens"] = req.MaxTokens
+	} else {
+		claudeReq["max_tokens"] = 4096
 	}
 	if req.Temperature > 0 {
 		claudeReq["temperature"] = req.Temperature

--- a/backend-go/internal/converters/converter_test.go
+++ b/backend-go/internal/converters/converter_test.go
@@ -276,6 +276,55 @@ func TestClaudeConverter_WithInstructions(t *testing.T) {
 	}
 }
 
+func TestClaudeConverter_DefaultMaxTokens(t *testing.T) {
+	converter := &ClaudeConverter{}
+	sess := &session.Session{
+		ID:       "sess_test",
+		Messages: []types.ResponsesItem{},
+	}
+
+	req := &types.ResponsesRequest{
+		Model:     "claude-3-opus",
+		Input:     "Hello!",
+		MaxTokens: 0, // 客户端未传 max_output_tokens
+	}
+
+	result, err := converter.ToProviderRequest(sess, req)
+	if err != nil {
+		t.Fatalf("转换失败: %v", err)
+	}
+
+	resultMap := result.(map[string]interface{})
+
+	// 当客户端未传 max_output_tokens 时，应使用默认值 4096
+	if resultMap["max_tokens"] != 4096 {
+		t.Errorf("默认 max_tokens 应为 4096，实际为 %v", resultMap["max_tokens"])
+	}
+}
+
+func TestResponsesPassthroughConverter_SkipsZeroMaxTokens(t *testing.T) {
+	converter := &ResponsesPassthroughConverter{}
+	sess := &session.Session{}
+
+	req := &types.ResponsesRequest{
+		Model:     "gpt-4",
+		Input:     "Hello!",
+		MaxTokens: 0, // 客户端未传 max_output_tokens
+	}
+
+	result, err := converter.ToProviderRequest(sess, req)
+	if err != nil {
+		t.Fatalf("转换失败: %v", err)
+	}
+
+	resultMap := result.(map[string]interface{})
+
+	// 当客户端未传 max_output_tokens 时，不应包含 max_tokens 字段
+	if _, ok := resultMap["max_tokens"]; ok {
+		t.Errorf("max_tokens 不应出现在透传请求中，当客户端未提供时")
+	}
+}
+
 // ============== 工厂模式测试 ==============
 
 func TestConverterFactory(t *testing.T) {

--- a/backend-go/internal/converters/responses_passthrough.go
+++ b/backend-go/internal/converters/responses_passthrough.go
@@ -14,13 +14,12 @@ type ResponsesPassthroughConverter struct{}
 // ToProviderRequest 透传 Responses 请求（不做转换）
 func (c *ResponsesPassthroughConverter) ToProviderRequest(sess *session.Session, req *types.ResponsesRequest) (interface{}, error) {
 	// 直接返回原始请求
-	return map[string]interface{}{
+	reqMap := map[string]interface{}{
 		"model":                req.Model,
 		"instructions":         req.Instructions,
 		"input":                req.Input,
 		"previous_response_id": req.PreviousResponseID,
 		"store":                req.Store,
-		"max_tokens":           req.MaxTokens,
 		"temperature":          req.Temperature,
 		"top_p":                req.TopP,
 		"frequency_penalty":    req.FrequencyPenalty,
@@ -29,7 +28,11 @@ func (c *ResponsesPassthroughConverter) ToProviderRequest(sess *session.Session,
 		"stop":                 req.Stop,
 		"user":                 req.User,
 		"stream_options":       req.StreamOptions,
-	}, nil
+	}
+	if req.MaxTokens > 0 {
+		reqMap["max_tokens"] = req.MaxTokens
+	}
+	return reqMap, nil
 }
 
 // FromProviderResponse 透传 Responses 响应（不做转换）


### PR DESCRIPTION
问题：Codex CLI 发出的 Responses 请求不包含 max_output_tokens， CCX 转发到 Anthropic格式的代理 时未注入 max_tokens 默认值，导致 Anthropic API 返回 400 错误（max_tokens 是必填字段）。

修复：
- ClaudeConverter: 当 req.MaxTokens == 0 时，默认设置为 4096， 与 Chat 链路保持一致
- ResponsesPassthroughConverter: 当 req.MaxTokens == 0 时， 不再透传 "max_tokens": 0，避免上游 Responses API 误解

新增测试覆盖默认 max_tokens 行为。