### PR TITLE
fix: skip base64 image data in local compact transcript

### DIFF
--- a/backend-go/internal/handlers/responses/compact_local.go
+++ b/backend-go/internal/handlers/responses/compact_local.go
@@ -128,13 +128,8 @@ func extractContentText(content interface{}) string {
 					texts = append(texts, t)
 				}
 			case "input_image":
-				url, _ := m["image_url"].(string)
-				if url == "" {
-					if urlObj, ok := m["image_url"].(map[string]interface{}); ok {
-						url, _ = urlObj["url"].(string)
-					}
-				}
-				texts = append(texts, fmt.Sprintf("[Image: %s]", url))
+				// Skip base64 image data - only output placeholder to avoid polluting transcript
+				texts = append(texts, "[Image]")
 			default:
 				if t, ok := m["text"].(string); ok && t != "" {
 					texts = append(texts, t)

--- a/backend-go/internal/handlers/responses/compact_local_test.go
+++ b/backend-go/internal/handlers/responses/compact_local_test.go
@@ -69,21 +69,61 @@ func TestFormatItemsAsTranscript_ContentBlocks(t *testing.T) {
 }
 
 func TestFormatItemsAsTranscript_InputImage(t *testing.T) {
-	items := []types.ResponsesItem{
-		{Type: "message", Role: "user", Content: []interface{}{
-			map[string]interface{}{"type": "input_text", "text": "Describe this image"},
-			map[string]interface{}{"type": "input_image", "image_url": "data:image/png;base64,SGVsbG8gV29ybGQh..."},
-		}},
+	tests := []struct {
+		name     string
+		imageURL interface{}
+		leaks    []string
+	}{
+		{
+			name:     "base64 string image_url",
+			imageURL: "data:image/png;base64,SGVsbG8gV29ybGQh...",
+			leaks:    []string{"data:image", "base64", "SGVsbG8gV29ybGQh"},
+		},
+		{
+			name: "base64 object image_url",
+			imageURL: map[string]interface{}{
+				"url": "data:image/jpeg;base64,QUJDREVGRw==",
+			},
+			leaks: []string{"data:image", "base64", "QUJDREVGRw"},
+		},
+		{
+			name:     "remote string image_url",
+			imageURL: "https://example.com/images/cat.png",
+			leaks:    []string{"https://example.com/images/cat.png", "example.com"},
+		},
+		{
+			name: "remote object image_url",
+			imageURL: map[string]interface{}{
+				"url": "https://cdn.example.com/images/dog.png",
+			},
+			leaks: []string{"https://cdn.example.com/images/dog.png", "cdn.example.com"},
+		},
 	}
-	transcript := formatItemsAsTranscript(items)
-	if !strings.Contains(transcript, "[Image]") {
-		t.Fatalf("expected [Image] placeholder, got: %s", transcript)
-	}
-	if strings.Contains(transcript, "data:image") || strings.Contains(transcript, "base64") {
-		t.Fatalf("base64 data leaked into transcript: %s", transcript)
-	}
-	if !strings.Contains(transcript, "Describe this image") {
-		t.Fatalf("text content should be preserved: %s", transcript)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			items := []types.ResponsesItem{
+				{Type: "message", Role: "user", Content: []interface{}{
+					map[string]interface{}{"type": "input_text", "text": "Describe this image"},
+					map[string]interface{}{"type": "input_image", "image_url": tt.imageURL, "detail": "high"},
+				}},
+			}
+			transcript := formatItemsAsTranscript(items)
+			if !strings.Contains(transcript, "[Image]") {
+				t.Fatalf("expected [Image] placeholder, got: %s", transcript)
+			}
+			if strings.Contains(transcript, "[Image:") {
+				t.Fatalf("image URL should not be included in placeholder: %s", transcript)
+			}
+			for _, leak := range tt.leaks {
+				if strings.Contains(transcript, leak) {
+					t.Fatalf("image data leaked into transcript (%s): %s", leak, transcript)
+				}
+			}
+			if !strings.Contains(transcript, "Describe this image") {
+				t.Fatalf("text content should be preserved: %s", transcript)
+			}
+		})
 	}
 }
 

--- a/backend-go/internal/handlers/responses/compact_local_test.go
+++ b/backend-go/internal/handlers/responses/compact_local_test.go
@@ -68,6 +68,25 @@ func TestFormatItemsAsTranscript_ContentBlocks(t *testing.T) {
 	}
 }
 
+func TestFormatItemsAsTranscript_InputImage(t *testing.T) {
+	items := []types.ResponsesItem{
+		{Type: "message", Role: "user", Content: []interface{}{
+			map[string]interface{}{"type": "input_text", "text": "Describe this image"},
+			map[string]interface{}{"type": "input_image", "image_url": "data:image/png;base64,SGVsbG8gV29ybGQh..."},
+		}},
+	}
+	transcript := formatItemsAsTranscript(items)
+	if !strings.Contains(transcript, "[Image]") {
+		t.Fatalf("expected [Image] placeholder, got: %s", transcript)
+	}
+	if strings.Contains(transcript, "data:image") || strings.Contains(transcript, "base64") {
+		t.Fatalf("base64 data leaked into transcript: %s", transcript)
+	}
+	if !strings.Contains(transcript, "Describe this image") {
+		t.Fatalf("text content should be preserved: %s", transcript)
+	}
+}
+
 func TestTruncateTranscript(t *testing.T) {
 	long := strings.Repeat("a", localCompactMaxTranscriptRunes+1000)
 	result := truncateTranscript(long)


### PR DESCRIPTION
## Summary
- Fix local compact transcript including full base64 image data as plain text
- Prevents 503 errors and reconnection loops when conversations contain image attachments
- Only outputs  placeholder instead of the full base64 data URI

## Test Plan
- [ ] Test with Codex Responses API + image attachment
- [ ] Verify compact works without base64 pollution