### PR TITLE
fix(stream): skip empty object {} input in content_block_start to prevent false malformed tool_call detection

### DIFF
--- a/backend-go/internal/handlers/common/stream.go
+++ b/backend-go/internal/handlers/common/stream.go
@@ -222,7 +222,11 @@ func (t *StreamToolCallTracker) ProcessClaudeEvent(event string) (bool, string) 
 				state.Name = name
 			}
 			if input, exists := contentBlock["input"]; exists && !IsMalformedToolArguments(input) {
-				if b, err := json.Marshal(input); err == nil {
+				// 跳过空对象占位符 {} — 实际参数通过后续 input_json_delta 事件追加
+				// 否则会导致 "{}" + partial_json = 非法 JSON（如 "{}{\"key\":\"val\"}"）
+				if m, ok := input.(map[string]interface{}); ok && len(m) == 0 {
+					// skip empty object
+				} else if b, err := json.Marshal(input); err == nil {
 					state.Arguments.Write(b)
 				}
 			}


### PR DESCRIPTION
## Problem

When upstream (e.g. Kimi Coding) returns a tool_use, the content_block_start event includes `input: {}` (empty object placeholder). CCX writes this `{}` to the Arguments buffer, then appends `partial_json` from subsequent `input_json_delta` events:

```
content_block_start  → input: {}              → buffer = "{}"
input_json_delta     → partial_json: {"cmd"    → buffer = "{}{\"cmd\""
input_json_delta     → partial_json: :"ls"}   → buffer = "{}{\"cmd\":\"ls\"}"
```

The concatenated `{}{\"cmd\":\"ls\"}` is invalid JSON. When `content_block_stop` triggers `isMalformedNamedToolArguments`, it fails JSON parsing and incorrectly marks valid tool calls as malformed, causing:

1. `ProcessClaudeEvent` returns malformed=true
2. `PreflightStreamEvents` sets IsEmpty=true and MalformedToolCall=true
3. CCX returns `ErrEmptyStreamResponse`
4. The API key gets marked as failed and triggers failover
5. After repeated failures: circuit breaker opens → 503 All API keys failed

Log confirmation: `[Chat-EmptyResponse] 上游返回空或畸形 tool_call（流式，upstreamType=claude, tool=exec_command），触发 failover`

## Fix

Skip writing empty object `{}` from `content_block_start` input — the actual arguments arrive exclusively through `input_json_delta` events. This matches Anthropic's streaming spec where `input: {}` is a placeholder, not a prefix.

The fix only skips truly empty objects (`len(m) == 0`); if `input` contains actual data, it is still written to the buffer.

## Affected

- `ProcessClaudeEvent` in `common/stream.go` (affects Messages API preflight and Chat API preflight paths)
- Any tool with a name NOT in `toolRequiresArguments` list (e.g. custom tools like `exec_command`) that receives arguments via streaming deltas