### PR TITLE
fix: Kimi coding API SSE streaming compatibility

### DIFF
--- a/backend-go/internal/handlers/chat/handler.go
+++ b/backend-go/internal/handlers/chat/handler.go
@@ -1811,6 +1811,7 @@ func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model str
 			}
 		}
 		return
+	case "content_block_delta":
 		delta, ok := event["delta"].(map[string]interface{})
 		if !ok {
 			return

--- a/backend-go/internal/handlers/chat/handler.go
+++ b/backend-go/internal/handlers/chat/handler.go
@@ -21,16 +21,6 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-// stripSSEDataPrefix strips the SSE "data:" field prefix from a line.
-// Both "data:value" and "data: value" formats are accepted per SSE specification.
-func stripSSEDataPrefix(line string) (string, bool) {
-	const prefix = "data:"
-	if !strings.HasPrefix(line, prefix) {
-		return "", false
-	}
-	return strings.TrimPrefix(line[len(prefix):], " "), true
-}
-
 // Handler Chat Completions API 代理处理器
 // 支持多渠道调度：当配置多个渠道时自动启用
 func Handler(
@@ -1024,7 +1014,7 @@ func preflightChatStream(resp *http.Response, upstreamType string) (*chatStreamP
 
 func detectMalformedChatStreamLines(lines []string, upstreamType string, tracker chatToolTracker, chatTracker *openAIChatToolCallTracker) (bool, string) {
 	for _, line := range lines {
-		jsonData, ok := stripSSEDataPrefix(line)
+		jsonData, ok := common.ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1151,7 +1141,7 @@ func fallbackChatToolName(name string, index int) string {
 
 func chatStreamHasTextContent(lines []string, upstreamType string) bool {
 	for _, line := range lines {
-		jsonData, ok := stripSSEDataPrefix(line)
+		jsonData, ok := common.ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1234,7 +1224,7 @@ func streamPassthrough(
 
 			// 尝试从完整行中提取 usage
 			for _, line := range completeLines {
-				jsonData, ok := stripSSEDataPrefix(line)
+				jsonData, ok := common.ExtractSSEJSONLine(line)
 				if !ok {
 					continue
 				}
@@ -1273,7 +1263,7 @@ func streamPassthrough(
 
 func flushCompletePassthroughRemainder(c *gin.Context, flusher http.Flusher, remainder string) {
 	trimmed := strings.TrimSpace(remainder)
-	jsonData, ok := stripSSEDataPrefix(trimmed)
+	jsonData, ok := common.ExtractSSEJSONLine(trimmed)
 	if !ok {
 		return
 	}
@@ -1569,7 +1559,7 @@ func streamResponsesToChat(
 					currentEventType = strings.TrimPrefix(line, "event: ")
 					continue
 				}
-				jsonData, ok := stripSSEDataPrefix(line)
+				jsonData, ok := common.ExtractSSEJSONLine(line)
 				if !ok {
 					continue
 				}
@@ -1755,7 +1745,7 @@ func writeChatSSEChunk(c *gin.Context, flusher http.Flusher, chunk map[string]in
 }
 
 func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model string, line string, totalUsage **types.Usage, doneSent *bool) {
-	jsonData, ok := stripSSEDataPrefix(line)
+	jsonData, ok := common.ExtractSSEJSONLine(line)
 	if !ok {
 		return
 	}

--- a/backend-go/internal/handlers/chat/handler.go
+++ b/backend-go/internal/handlers/chat/handler.go
@@ -21,6 +21,16 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
+// stripSSEDataPrefix strips the SSE "data:" field prefix from a line.
+// Both "data:value" and "data: value" formats are accepted per SSE specification.
+func stripSSEDataPrefix(line string) (string, bool) {
+	const prefix = "data:"
+	if !strings.HasPrefix(line, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(line[len(prefix):], " "), true
+}
+
 // Handler Chat Completions API 代理处理器
 // 支持多渠道调度：当配置多个渠道时自动启用
 func Handler(
@@ -1014,10 +1024,10 @@ func preflightChatStream(resp *http.Response, upstreamType string) (*chatStreamP
 
 func detectMalformedChatStreamLines(lines []string, upstreamType string, tracker chatToolTracker, chatTracker *openAIChatToolCallTracker) (bool, string) {
 	for _, line := range lines {
-		if !strings.HasPrefix(line, "data: ") {
+		jsonData, ok := stripSSEDataPrefix(line)
+		if !ok {
 			continue
 		}
-		jsonData := strings.TrimPrefix(line, "data: ")
 		if jsonData == "[DONE]" {
 			continue
 		}
@@ -1141,10 +1151,10 @@ func fallbackChatToolName(name string, index int) string {
 
 func chatStreamHasTextContent(lines []string, upstreamType string) bool {
 	for _, line := range lines {
-		if !strings.HasPrefix(line, "data: ") {
+		jsonData, ok := stripSSEDataPrefix(line)
+		if !ok {
 			continue
 		}
-		jsonData := strings.TrimPrefix(line, "data: ")
 		if jsonData == "[DONE]" {
 			continue
 		}
@@ -1224,10 +1234,10 @@ func streamPassthrough(
 
 			// 尝试从完整行中提取 usage
 			for _, line := range completeLines {
-				if !strings.HasPrefix(line, "data: ") {
+				jsonData, ok := stripSSEDataPrefix(line)
+				if !ok {
 					continue
 				}
-				jsonData := strings.TrimPrefix(line, "data: ")
 				if jsonData == "[DONE]" {
 					continue
 				}
@@ -1263,10 +1273,10 @@ func streamPassthrough(
 
 func flushCompletePassthroughRemainder(c *gin.Context, flusher http.Flusher, remainder string) {
 	trimmed := strings.TrimSpace(remainder)
-	if !strings.HasPrefix(trimmed, "data: ") {
+	jsonData, ok := stripSSEDataPrefix(trimmed)
+	if !ok {
 		return
 	}
-	jsonData := strings.TrimPrefix(trimmed, "data: ")
 	if jsonData != "[DONE]" && !json.Valid([]byte(jsonData)) {
 		return
 	}
@@ -1559,10 +1569,10 @@ func streamResponsesToChat(
 					currentEventType = strings.TrimPrefix(line, "event: ")
 					continue
 				}
-				if !strings.HasPrefix(line, "data: ") {
+				jsonData, ok := stripSSEDataPrefix(line)
+				if !ok {
 					continue
 				}
-				jsonData := strings.TrimPrefix(line, "data: ")
 				if jsonData == "[DONE]" {
 					continue
 				}
@@ -1745,10 +1755,10 @@ func writeChatSSEChunk(c *gin.Context, flusher http.Flusher, chunk map[string]in
 }
 
 func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model string, line string, totalUsage **types.Usage, doneSent *bool) {
-	if !strings.HasPrefix(line, "data: ") {
+	jsonData, ok := stripSSEDataPrefix(line)
+	if !ok {
 		return
 	}
-	jsonData := strings.TrimPrefix(line, "data: ")
 	if jsonData == "[DONE]" {
 		fmt.Fprintf(c.Writer, "data: [DONE]\n\n")
 		if flusher != nil {

--- a/backend-go/internal/handlers/chat/handler.go
+++ b/backend-go/internal/handlers/chat/handler.go
@@ -1288,6 +1288,8 @@ func streamClaudeToChat(
 ) *types.Usage {
 	var totalUsage *types.Usage
 	var doneSent bool
+	var currentToolCallID string
+	currentToolIndex := 0
 	buf := make([]byte, 32*1024)
 	var remainder string
 	pending := prefetched
@@ -1315,13 +1317,13 @@ func streamClaudeToChat(
 			remainder = lines[len(lines)-1]
 			lines = lines[:len(lines)-1]
 			for _, line := range lines {
-				processClaudeChatStreamLine(c, flusher, model, line, &totalUsage, &doneSent)
+				processClaudeChatStreamLine(c, flusher, model, line, &totalUsage, &doneSent, &currentToolCallID, &currentToolIndex)
 			}
 		}
 
 		if readErr != nil {
 			if remainder != "" {
-				processClaudeChatStreamLine(c, flusher, model, remainder, &totalUsage, &doneSent)
+				processClaudeChatStreamLine(c, flusher, model, remainder, &totalUsage, &doneSent, &currentToolCallID, &currentToolIndex)
 				remainder = ""
 			}
 			break
@@ -1744,7 +1746,7 @@ func writeChatSSEChunk(c *gin.Context, flusher http.Flusher, chunk map[string]in
 	}
 }
 
-func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model string, line string, totalUsage **types.Usage, doneSent *bool) {
+func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model string, line string, totalUsage **types.Usage, doneSent *bool, currentToolCallID *string, currentToolIndex *int) {
 	jsonData, ok := common.ExtractSSEJSONLine(line)
 	if !ok {
 		return
@@ -1765,7 +1767,50 @@ func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model str
 
 	eventType, _ := event["type"].(string)
 	switch eventType {
-	case "content_block_delta":
+	case "content_block_start":
+		cb, _ := event["content_block"].(map[string]interface{})
+		if cb == nil {
+			return
+		}
+		cbType, _ := cb["type"].(string)
+		if cbType == "tool_use" {
+			idx := 0
+			if i, ok := event["index"].(float64); ok {
+				idx = int(i)
+			}
+			name, _ := cb["name"].(string)
+			tid, _ := cb["id"].(string)
+			*currentToolCallID = tid
+			*currentToolIndex = idx
+			// 发送 tool_calls delta 起始块（包含 index/id/name）
+			chatChunk := map[string]interface{}{
+				"id":      "chatcmpl-claude",
+				"object":  "chat.completion.chunk",
+				"created": time.Now().Unix(),
+				"model":   model,
+				"choices": []map[string]interface{}{{
+					"index": 0,
+					"delta": map[string]interface{}{
+						"tool_calls": []map[string]interface{}{{
+							"index": idx,
+							"id":    tid,
+							"type":  "function",
+							"function": map[string]interface{}{
+								"name":      name,
+								"arguments": "",
+							},
+						}},
+					},
+					"finish_reason": nil,
+				}},
+			}
+			chunkBytes, _ := json.Marshal(chatChunk)
+			fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunkBytes))
+			if flusher != nil {
+				flusher.Flush()
+			}
+		}
+		return
 		delta, ok := event["delta"].(map[string]interface{})
 		if !ok {
 			return
@@ -1815,8 +1860,45 @@ func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model str
 			if flusher != nil {
 				flusher.Flush()
 			}
+		case "input_json_delta":
+			partial, _ := delta["partial_json"].(string)
+			if partial == "" {
+				return
+			}
+			chatChunk := map[string]interface{}{
+				"id":      "chatcmpl-claude",
+				"object":  "chat.completion.chunk",
+				"created": time.Now().Unix(),
+				"model":   model,
+				"choices": []map[string]interface{}{{
+					"index": 0,
+					"delta": map[string]interface{}{
+						"tool_calls": []map[string]interface{}{{
+							"index": *currentToolIndex,
+							"function": map[string]interface{}{
+								"arguments": partial,
+							},
+						}},
+					},
+					"finish_reason": nil,
+				}},
+			}
+			chunkBytes, _ := json.Marshal(chatChunk)
+			fmt.Fprintf(c.Writer, "data: %s\n\n", string(chunkBytes))
+			if flusher != nil {
+				flusher.Flush()
+			}
 		}
 	case "message_delta":
+		// 根据 stop_reason 推导 finish_reason
+		finishReason := "stop"
+		if delta, ok := event["delta"].(map[string]interface{}); ok {
+			if sr, _ := delta["stop_reason"].(string); sr == "tool_use" || sr == "server_tool_use" {
+				finishReason = "tool_calls"
+			} else if sr == "max_tokens" {
+				finishReason = "length"
+			}
+		}
 		stopChunk := map[string]interface{}{
 			"id":      "chatcmpl-claude",
 			"object":  "chat.completion.chunk",
@@ -1825,7 +1907,7 @@ func processClaudeChatStreamLine(c *gin.Context, flusher http.Flusher, model str
 			"choices": []map[string]interface{}{{
 				"index":         0,
 				"delta":         map[string]interface{}{},
-				"finish_reason": "stop",
+				"finish_reason": finishReason,
 			}},
 		}
 		if usage, ok := event["usage"].(map[string]interface{}); ok {

--- a/backend-go/internal/handlers/common/stream.go
+++ b/backend-go/internal/handlers/common/stream.go
@@ -194,7 +194,7 @@ func (t *StreamToolCallTracker) HasPendingToolCall() bool {
 
 func (t *StreamToolCallTracker) ProcessClaudeEvent(event string) (bool, string) {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -257,7 +257,7 @@ func (t *StreamToolCallTracker) ProcessClaudeEvent(event string) (bool, string) 
 
 func (t *StreamToolCallTracker) ProcessResponsesEvent(event string) (bool, string) {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -410,7 +410,7 @@ func fallbackToolName(name string, index int) string {
 
 func isUsageOnlySSEEvent(event string) bool {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -432,7 +432,7 @@ func firstUnknownSSEDataType(event string) (string, bool) {
 		"message_start": {}, "message_delta": {}, "message_stop": {}, "content_block_start": {}, "content_block_delta": {}, "content_block_stop": {}, "ping": {}, "error": {},
 	}
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -463,7 +463,7 @@ func IsEffectivelyEmptyStreamText(text string) bool {
 	return text == "" || strings.TrimSpace(text) == "{"
 }
 
-func extractSSEJSONLine(line string) (string, bool) {
+func ExtractSSEJSONLine(line string) (string, bool) {
 	if !strings.HasPrefix(line, "data:") {
 		return "", false
 	}
@@ -480,7 +480,7 @@ func hasNonTextContentBlock(event string) bool {
 // HasClaudeSemanticContent 判断 Claude/Messages 风格 SSE 是否包含有效语义内容
 func HasClaudeSemanticContent(event string) bool {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -526,7 +526,7 @@ func responseItemCarriesSemanticContent(item map[string]interface{}) bool {
 func HasResponsesSemanticContent(event string) bool {
 	lines := strings.Split(event, "\n")
 	for _, line := range lines {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1237,7 +1237,7 @@ func annotatePromptTokensTotalForProvider(provider providers.Provider, usage *ty
 // CheckEventUsageStatus 检测事件是否包含 usage 字段
 func CheckEventUsageStatus(event string, enableLog bool) (bool, bool, bool, CollectedUsageData) {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1764,7 +1764,7 @@ func IsMessageDeltaEvent(event string) bool {
 		return true
 	}
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1783,7 +1783,7 @@ func IsMessageDeltaEvent(event string) bool {
 // 支持 message_start 事件的 message.usage.input_tokens 和顶层 usage.input_tokens
 func ExtractInputTokensFromEvent(event string) int {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1815,7 +1815,7 @@ func ExtractInputTokensFromEvent(event string) int {
 // ExtractTextFromEvent 从 SSE 事件中提取文本内容
 func ExtractTextFromEvent(event string, buf *bytes.Buffer) {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1847,7 +1847,7 @@ func ExtractTextFromEvent(event string, buf *bytes.Buffer) {
 // ExtractThinkingFromEvent 从 SSE 事件中提取 thinking 内容
 func ExtractThinkingFromEvent(event string, buf *bytes.Buffer) {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1894,7 +1894,7 @@ func DetectStreamBlacklistError(event string) (reason string, message string) {
 
 	// 即使不是显式的 event: error，也检查 data 中的 type == "error"
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}
@@ -1992,7 +1992,7 @@ func truncateMsg(msg string) string {
 // extractSSEEventInfo 从 SSE 事件中提取事件类型、block 索引和 block 类型
 func extractSSEEventInfo(event string) (eventType string, blockIndex int, blockType string) {
 	for _, line := range strings.Split(event, "\n") {
-		jsonStr, ok := extractSSEJSONLine(line)
+		jsonStr, ok := ExtractSSEJSONLine(line)
 		if !ok {
 			continue
 		}

--- a/backend-go/internal/handlers/common/stream.go
+++ b/backend-go/internal/handlers/common/stream.go
@@ -222,7 +222,11 @@ func (t *StreamToolCallTracker) ProcessClaudeEvent(event string) (bool, string) 
 				state.Name = name
 			}
 			if input, exists := contentBlock["input"]; exists && !IsMalformedToolArguments(input) {
-				if b, err := json.Marshal(input); err == nil {
+				// 跳过空对象占位符 {} — 实际参数通过后续 input_json_delta 事件追加
+				// 否则会导致 "{}" + partial_json = 非法 JSON（如 "{}{\"key\":\"val\"}"）
+				if m, ok := input.(map[string]interface{}); ok && len(m) == 0 {
+					// skip empty object
+				} else if b, err := json.Marshal(input); err == nil {
 					state.Arguments.Write(b)
 				}
 			}


### PR DESCRIPTION
## Problem

Kimi Coding API (api.kimi.com/coding) returns SSE events in a format that differs
from standard Anthropic in two ways, causing CCX streaming to fail:

1. **SSE data field without space**: `data:{...}` instead of `data: {...}`
   - Chat handler's strict `"data: "` prefix check drops all content lines
   - Result: only `data: [DONE]` with no delta chunks

2. **Tool_use empty input placeholder**: `content_block_start.input: {}` 
   - Written to Arguments buffer, then `input_json_delta` fragments appended
   - Result: `{}{"key":"val"}` invalid JSON → malformed detection → `ErrEmptyStreamResponse`

3. **Tool_use events silently dropped**: Chat handler's `processClaudeChatStreamLine`
   only handled `text_delta`/`thinking_delta`, not `tool_use`/`input_json_delta` events
   - Result: streaming clients never receive `tool_calls` delta chunks

## Changes

### 1. Export `ExtractSSEJSONLine` (common/stream.go)
Rename `extractSSEJSONLine` → `ExtractSSEJSONLine` for reuse across packages.

### 2. Fix SSE data prefix (chat/handler.go)
Replace all 6 strict `"data: "` checks with tolerant `common.ExtractSSEJSONLine`.

### 3. Skip empty input placeholder (common/stream.go)
In `ProcessClaudeEvent`: don't write `{}` from `content_block_start` input
when it's an empty object — arguments arrive via `input_json_delta` events.

### 4. Add tool_use streaming conversion (chat/handler.go)
- `content_block_start` tool_use → OpenAI `tool_calls` chunk (name, id, index)
- `input_json_delta` → OpenAI `tool_calls.function.arguments` chunks
- Derive `finish_reason` from `stop_reason` (tool_use→"tool_calls", max_tokens→"length")

## Testing

- Non-streaming: unaffected (doesn't use line-by-line SSE parsing)
- Streaming plain text: ✅ content delta chunks correctly streamed
- Streaming with tool calls: ✅ tool_calls chunks + arguments streamed, no false malformed detection