### PR TITLE
Fix Claude Code tool-use follow-up for Kimi /coding Claude upstream

### DIFF
--- a/backend-go/internal/providers/claude.go
+++ b/backend-go/internal/providers/claude.go
@@ -597,15 +597,16 @@ func (p *ClaudeProvider) ConvertToProviderRequest(c *gin.Context, upstream *conf
 		bodyBytes = redirectModelInBody(bodyBytes, upstream)
 	}
 
-	if upstream.PassbackReasoningContent {
+	passbackReasoningContent := shouldPassbackReasoningContent(upstream)
+	if passbackReasoningContent {
 		bodyBytes = convertThinkingToReasoningContent(bodyBytes)
 	}
 	if upstream.PassbackThinkingBlocks {
-		bodyBytes = convertReasoningContentToThinkingBlocks(bodyBytes, upstream.PassbackReasoningContent)
+		bodyBytes = convertReasoningContentToThinkingBlocks(bodyBytes, passbackReasoningContent)
 	}
 	if upstream.StripEmptyTextBlocks {
 		bodyBytes = stripEmptyTextBlocksFromBody(bodyBytes)
-		if !upstream.PassbackReasoningContent && !upstream.PassbackThinkingBlocks {
+		if !passbackReasoningContent && !upstream.PassbackThinkingBlocks {
 			bodyBytes = stripThinkingBlocksFromBody(bodyBytes)
 		}
 	}
@@ -666,6 +667,21 @@ func (p *ClaudeProvider) ConvertToProviderRequest(c *gin.Context, upstream *conf
 	utils.EnsureCompatibleUserAgent(req.Header, "claude")
 
 	return req, bodyBytes, nil
+}
+
+func shouldPassbackReasoningContent(upstream *config.UpstreamConfig) bool {
+	if upstream == nil {
+		return false
+	}
+	if upstream.PassbackReasoningContent {
+		return true
+	}
+	switch strings.TrimSpace(upstream.ReasoningParamStyle) {
+	case "reasoning", "thinking":
+		return true
+	default:
+		return false
+	}
 }
 
 // ConvertToClaudeResponse 转换为 Claude 响应（直接透传）

--- a/backend-go/internal/providers/claude.go
+++ b/backend-go/internal/providers/claude.go
@@ -62,6 +62,10 @@ const (
 //
 // 注：函数名保留以维持向后兼容。
 func convertThinkingToReasoningContent(bodyBytes []byte) []byte {
+	return convertThinkingToReasoningContentWithOptions(bodyBytes, false)
+}
+
+func convertThinkingToReasoningContentWithOptions(bodyBytes []byte, synthesizeThinkingForToolUse bool) []byte {
 	decoder := json.NewDecoder(bytes.NewReader(bodyBytes))
 	decoder.UseNumber()
 
@@ -102,6 +106,8 @@ func convertThinkingToReasoningContent(bodyBytes []byte) []byte {
 		filteredContent := make([]interface{}, 0, len(content))
 		contentModified := false
 		reasoningParts := make([]string, 0, 1)
+		toolUseBlocks := make([]map[string]interface{}, 0, 1)
+		hasThinkingBlock := false
 		for _, block := range content {
 			blockMap, ok := block.(map[string]interface{})
 			if !ok {
@@ -111,6 +117,9 @@ func convertThinkingToReasoningContent(bodyBytes []byte) []byte {
 
 			blockType, _ := blockMap["type"].(string)
 			blockType = strings.TrimSpace(blockType)
+			if isAssistantToolUseBlock(blockType) {
+				toolUseBlocks = append(toolUseBlocks, blockMap)
+			}
 			thinking, _ := blockMap["thinking"].(string)
 			trimmedThinking := strings.TrimSpace(thinking)
 			if blockType == "thinking" {
@@ -123,6 +132,7 @@ func convertThinkingToReasoningContent(bodyBytes []byte) []byte {
 				// 为兼容上游思考回传校验，保留原始 thinking 文本，不做 trim 改写。
 				reasoningParts = append(reasoningParts, thinking)
 				// 保留真实 thinking block，避免部分上游按历史内容做一致性校验时报错。
+				hasThinkingBlock = true
 				filteredContent = append(filteredContent, blockMap)
 				continue
 			}
@@ -151,6 +161,29 @@ func convertThinkingToReasoningContent(bodyBytes []byte) []byte {
 			modified = true
 			msgMap["reasoning_content"] = legacyThinkingPlaceholder
 		}
+		finalReasoning, _ := msgMap["reasoning_content"].(string)
+		if strings.TrimSpace(finalReasoning) != "" {
+			for _, blockMap := range toolUseBlocks {
+				if blockReasoning, _ := blockMap["reasoning_content"].(string); blockReasoning == finalReasoning {
+					continue
+				}
+				blockMap["reasoning_content"] = finalReasoning
+				modified = true
+				contentModified = true
+			}
+		}
+		if synthesizeThinkingForToolUse && len(toolUseBlocks) > 0 && !hasThinkingBlock {
+			thinking := finalReasoning
+			if strings.TrimSpace(thinking) == "" {
+				thinking = legacyThinkingPlaceholder
+			}
+			filteredContent = append([]interface{}{map[string]interface{}{
+				"type":     "thinking",
+				"thinking": thinking,
+			}}, filteredContent...)
+			modified = true
+			contentModified = true
+		}
 
 		if len(filteredContent) == 0 {
 			modified = true
@@ -176,6 +209,15 @@ func convertThinkingToReasoningContent(bodyBytes []byte) []byte {
 		return bodyBytes
 	}
 	return newBytes
+}
+
+func isAssistantToolUseBlock(blockType string) bool {
+	switch strings.TrimSpace(blockType) {
+	case "tool_use", "server_tool_use":
+		return true
+	default:
+		return false
+	}
 }
 
 // convertReasoningContentToThinkingBlocks 将真实 reasoning_content 投影为 Claude thinking 块。
@@ -599,7 +641,7 @@ func (p *ClaudeProvider) ConvertToProviderRequest(c *gin.Context, upstream *conf
 
 	passbackReasoningContent := shouldPassbackReasoningContent(upstream)
 	if passbackReasoningContent {
-		bodyBytes = convertThinkingToReasoningContent(bodyBytes)
+		bodyBytes = convertThinkingToReasoningContentWithOptions(bodyBytes, shouldSynthesizeThinkingForToolUse(upstream))
 	}
 	if upstream.PassbackThinkingBlocks {
 		bodyBytes = convertReasoningContentToThinkingBlocks(bodyBytes, passbackReasoningContent)
@@ -667,6 +709,18 @@ func (p *ClaudeProvider) ConvertToProviderRequest(c *gin.Context, upstream *conf
 	utils.EnsureCompatibleUserAgent(req.Header, "claude")
 
 	return req, bodyBytes, nil
+}
+
+func shouldSynthesizeThinkingForToolUse(upstream *config.UpstreamConfig) bool {
+	if upstream == nil {
+		return false
+	}
+	if upstream.PassbackThinkingBlocks {
+		return true
+	}
+	baseURL := strings.ToLower(strings.TrimSpace(upstream.BaseURL))
+	name := strings.ToLower(strings.TrimSpace(upstream.Name))
+	return strings.Contains(baseURL, "api.kimi.com/coding") || (strings.Contains(name, "kimi") && strings.Contains(baseURL, "/coding"))
 }
 
 func shouldPassbackReasoningContent(upstream *config.UpstreamConfig) bool {

--- a/backend-go/internal/providers/claude.go
+++ b/backend-go/internal/providers/claude.go
@@ -730,12 +730,23 @@ func shouldPassbackReasoningContent(upstream *config.UpstreamConfig) bool {
 	if upstream.PassbackReasoningContent {
 		return true
 	}
+	if isKimiCodingUpstream(upstream) {
+		return false
+	}
 	switch strings.TrimSpace(upstream.ReasoningParamStyle) {
 	case "reasoning", "thinking":
 		return true
 	default:
 		return false
 	}
+}
+
+func isKimiCodingUpstream(upstream *config.UpstreamConfig) bool {
+	if upstream == nil {
+		return false
+	}
+	baseURL := strings.ToLower(strings.TrimSpace(upstream.BaseURL))
+	return strings.Contains(baseURL, "api.kimi.com/coding")
 }
 
 // ConvertToClaudeResponse 转换为 Claude 响应（直接透传）

--- a/backend-go/internal/providers/claude_reasoning_test.go
+++ b/backend-go/internal/providers/claude_reasoning_test.go
@@ -211,7 +211,7 @@ func TestConvertThinkingToReasoningContent(t *testing.T) {
 						"reasoning_content": legacyThinkingPlaceholder,
 						"content": []interface{}{
 							map[string]interface{}{"type": "text", "text": "answer"},
-							map[string]interface{}{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": map[string]interface{}{"command": "pwd"}},
+							map[string]interface{}{"type": "tool_use", "id": "toolu_1", "name": "Bash", "input": map[string]interface{}{"command": "pwd"}, "reasoning_content": legacyThinkingPlaceholder},
 						},
 					},
 				},
@@ -400,7 +400,7 @@ func TestConvertThinkingToReasoningContent(t *testing.T) {
 						"role":              "assistant",
 						"reasoning_content": legacyThinkingPlaceholder,
 						"content": []interface{}{
-							map[string]interface{}{"type": "tool_use", "id": "call_x", "name": "Edit", "input": map[string]interface{}{"file_path": "a.go"}},
+							map[string]interface{}{"type": "tool_use", "id": "call_x", "name": "Edit", "input": map[string]interface{}{"file_path": "a.go"}, "reasoning_content": legacyThinkingPlaceholder},
 						},
 					},
 				},
@@ -416,7 +416,7 @@ func TestConvertThinkingToReasoningContent(t *testing.T) {
 						"role":              "assistant",
 						"reasoning_content": legacyThinkingPlaceholder,
 						"content": []interface{}{
-							map[string]interface{}{"type": "tool_use", "id": "call_y", "name": "Edit", "input": map[string]interface{}{"file_path": "b.go"}},
+							map[string]interface{}{"type": "tool_use", "id": "call_y", "name": "Edit", "input": map[string]interface{}{"file_path": "b.go"}, "reasoning_content": legacyThinkingPlaceholder},
 						},
 					},
 				},

--- a/backend-go/internal/providers/request_context_test.go
+++ b/backend-go/internal/providers/request_context_test.go
@@ -92,6 +92,22 @@ func TestClaudeProvider_ConvertToProviderRequest_ReasoningStyleAutoPassback(t *t
 	if !bytes.Contains(reqBody, []byte(`"type":"tool_use"`)) {
 		t.Fatalf("request body should keep tool_use block: %s", string(reqBody))
 	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(reqBody, &got); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	messages, _ := got["messages"].([]interface{})
+	assistant, _ := messages[1].(map[string]interface{})
+	content, _ := assistant["content"].([]interface{})
+	thinking, _ := content[0].(map[string]interface{})
+	if thinking["type"] != "thinking" || thinking["thinking"] != assistant["reasoning_content"] {
+		t.Fatalf("synthetic thinking block = %v, want thinking matching assistant reasoning_content %v", thinking, assistant["reasoning_content"])
+	}
+	toolUse, _ := content[1].(map[string]interface{})
+	if toolUse["reasoning_content"] != assistant["reasoning_content"] {
+		t.Fatalf("tool_use reasoning_content = %v, want assistant reasoning_content %v", toolUse["reasoning_content"], assistant["reasoning_content"])
+	}
 }
 
 func TestConvertToProviderRequest_PropagatesContext(t *testing.T) {

--- a/backend-go/internal/providers/request_context_test.go
+++ b/backend-go/internal/providers/request_context_test.go
@@ -62,6 +62,57 @@ func TestClaudeProvider_ConvertToProviderRequest_ReasoningStyleAutoPassback(t *t
 	gin.SetMode(gin.TestMode)
 
 	body := []byte(`{
+		"model": "mimo-v2.5-pro",
+		"thinking": {"type": "enabled"},
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "read"}]},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {"file_path": "/tmp/a"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_1", "content": "ok"}
+			]}
+		]
+	}`)
+	c := newGinContext(http.MethodPost, "/v1/messages", body, context.Background())
+	upstream := &config.UpstreamConfig{
+		BaseURL:             "https://api.example.com",
+		ServiceType:         "claude",
+		ReasoningParamStyle: "reasoning",
+	}
+
+	p := &ClaudeProvider{}
+	_, reqBody, err := p.ConvertToProviderRequest(c, upstream, "sk-kimi-test")
+	if err != nil {
+		t.Fatalf("ConvertToProviderRequest() err = %v", err)
+	}
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(reqBody, &got); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
+	}
+	messages, _ := got["messages"].([]interface{})
+	assistant, _ := messages[1].(map[string]interface{})
+	if _, ok := assistant["reasoning_content"]; !ok {
+		t.Fatalf("request body missing assistant.reasoning_content for generic reasoning upstream: %s", string(reqBody))
+	}
+	content, _ := assistant["content"].([]interface{})
+	found := false
+	for _, item := range content {
+		if block, ok := item.(map[string]interface{}); ok && block["type"] == "tool_use" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("request body should keep assistant tool_use block: %v", got["messages"])
+	}
+}
+
+func TestClaudeProvider_ConvertToProviderRequest_KimiCodingWithoutPassbackReasoning(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{
 		"model": "kimi-k2.6",
 		"thinking": {"type": "enabled"},
 		"messages": [
@@ -86,11 +137,54 @@ func TestClaudeProvider_ConvertToProviderRequest_ReasoningStyleAutoPassback(t *t
 	if err != nil {
 		t.Fatalf("ConvertToProviderRequest() err = %v", err)
 	}
-	if !bytes.Contains(reqBody, []byte(`"reasoning_content":"`)) {
-		t.Fatalf("request body missing auto reasoning_content: %s", string(reqBody))
+
+	var got map[string]interface{}
+	if err := json.Unmarshal(reqBody, &got); err != nil {
+		t.Fatalf("unmarshal request body: %v", err)
 	}
-	if !bytes.Contains(reqBody, []byte(`"type":"tool_use"`)) {
-		t.Fatalf("request body should keep tool_use block: %s", string(reqBody))
+	if _, ok := got["reasoning_content"]; ok {
+		t.Fatalf("request body should not include reasoning_content for /coding by default: %s", string(reqBody))
+	}
+	messages, _ := got["messages"].([]interface{})
+	assistant, _ := messages[1].(map[string]interface{})
+	if _, ok := assistant["reasoning_content"]; ok {
+		t.Fatalf("assistant message should not include reasoning_content for /coding by default: %s", string(reqBody))
+	}
+	content, _ := assistant["content"].([]interface{})
+	found := false
+	for _, item := range content {
+		if block, ok := item.(map[string]interface{}); ok && block["type"] == "tool_use" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("request body should keep assistant tool_use block: %v", got["messages"])
+	}
+}
+
+func TestClaudeProvider_ConvertToProviderRequest_ExplicitPassbackReasoningContent(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{
+		"model": "kimi-k2.6",
+		"messages": [
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "toolu_1", "name": "Edit", "input": {"file_path": "a.go"}}
+			]}
+		]
+	}`)
+	c := newGinContext(http.MethodPost, "/v1/messages", body, context.Background())
+	upstream := &config.UpstreamConfig{
+		BaseURL:                  "https://api.kimi.com/coding",
+		ServiceType:              "claude",
+		PassbackReasoningContent: true,
+	}
+
+	p := &ClaudeProvider{}
+	_, reqBody, err := p.ConvertToProviderRequest(c, upstream, "sk-kimi-test")
+	if err != nil {
+		t.Fatalf("ConvertToProviderRequest() err = %v", err)
 	}
 
 	var got map[string]interface{}
@@ -98,15 +192,23 @@ func TestClaudeProvider_ConvertToProviderRequest_ReasoningStyleAutoPassback(t *t
 		t.Fatalf("unmarshal request body: %v", err)
 	}
 	messages, _ := got["messages"].([]interface{})
-	assistant, _ := messages[1].(map[string]interface{})
-	content, _ := assistant["content"].([]interface{})
-	thinking, _ := content[0].(map[string]interface{})
-	if thinking["type"] != "thinking" || thinking["thinking"] != assistant["reasoning_content"] {
-		t.Fatalf("synthetic thinking block = %v, want thinking matching assistant reasoning_content %v", thinking, assistant["reasoning_content"])
+	if len(messages) == 0 {
+		t.Fatalf("request body messages empty")
 	}
-	toolUse, _ := content[1].(map[string]interface{})
-	if toolUse["reasoning_content"] != assistant["reasoning_content"] {
-		t.Fatalf("tool_use reasoning_content = %v, want assistant reasoning_content %v", toolUse["reasoning_content"], assistant["reasoning_content"])
+	assistant, _ := messages[0].(map[string]interface{})
+	if _, ok := assistant["reasoning_content"]; !ok {
+		t.Fatalf("explicit passback should add assistant.reasoning_content: %s", string(reqBody))
+	}
+	content, _ := assistant["content"].([]interface{})
+	found := false
+	for _, item := range content {
+		if block, ok := item.(map[string]interface{}); ok && block["type"] == "tool_use" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("request body should keep assistant tool_use block: %v", got["messages"])
 	}
 }
 

--- a/backend-go/internal/providers/request_context_test.go
+++ b/backend-go/internal/providers/request_context_test.go
@@ -58,6 +58,42 @@ func TestClaudeProvider_ConvertToProviderRequest_PassbackConvertsRealThinking(t 
 	}
 }
 
+func TestClaudeProvider_ConvertToProviderRequest_ReasoningStyleAutoPassback(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	body := []byte(`{
+		"model": "kimi-k2.6",
+		"thinking": {"type": "enabled"},
+		"messages": [
+			{"role": "user", "content": [{"type": "text", "text": "read"}]},
+			{"role": "assistant", "content": [
+				{"type": "tool_use", "id": "toolu_1", "name": "Read", "input": {"file_path": "/tmp/a"}}
+			]},
+			{"role": "user", "content": [
+				{"type": "tool_result", "tool_use_id": "toolu_1", "content": "ok"}
+			]}
+		]
+	}`)
+	c := newGinContext(http.MethodPost, "/v1/messages", body, context.Background())
+	upstream := &config.UpstreamConfig{
+		BaseURL:             "https://api.kimi.com/coding",
+		ServiceType:         "claude",
+		ReasoningParamStyle: "reasoning",
+	}
+
+	p := &ClaudeProvider{}
+	_, reqBody, err := p.ConvertToProviderRequest(c, upstream, "sk-kimi-test")
+	if err != nil {
+		t.Fatalf("ConvertToProviderRequest() err = %v", err)
+	}
+	if !bytes.Contains(reqBody, []byte(`"reasoning_content":"`)) {
+		t.Fatalf("request body missing auto reasoning_content: %s", string(reqBody))
+	}
+	if !bytes.Contains(reqBody, []byte(`"type":"tool_use"`)) {
+		t.Fatalf("request body should keep tool_use block: %s", string(reqBody))
+	}
+}
+
 func TestConvertToProviderRequest_PropagatesContext(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 


### PR DESCRIPTION
### 关联 Issue

Fixes #213

### 变更说明

根据 maintainer 给出的修复方向，更新了 Kimi /coding 的处理逻辑：

- 保留并透传 Claude 历史消息中的 `thinking` block；
- 当上游为 Kimi `/coding` 且未显式设置 `PassbackReasoningContent` 时，不再自动注入 `reasoning_content` 或给 `tool_use` 附加 `reasoning_content`；
- 当 `PassbackReasoningContent=true` 时仍保留已有显式 passback 行为；
- 新增/调整单测覆盖：
  - `ReasoningParamStyle` 在非 Kimi 上游仍会自动 passback；
  - `api.kimi.com/coding` 在默认配置下不进行 auto passback。
