### PR TITLE
fix: 修复 Docker 本地构建失败 (fix #227)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH
 
 WORKDIR /src
 
-RUN apk add --no-cache git make libstdc++ libgcc
+RUN apk add --no-cache bash git make libstdc++ libgcc
 
 COPY --from=bun-runtime /usr/local/bin/bun /usr/local/bin/bun
 COPY --from=bun-runtime /usr/local/bin/bunx /usr/local/bin/bunx
@@ -29,6 +29,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
 COPY Makefile ./
 COPY frontend/ ./frontend/
 COPY backend-go/ ./backend-go/
+COPY scripts/ ./scripts/
 COPY VERSION ./
 
 # 构建：交叉编译目标平台，利用 Go build cache

--- a/scripts/embed-frontend.sh
+++ b/scripts/embed-frontend.sh
@@ -23,8 +23,8 @@ compute_hash() {
     "$FRONTEND_DIR/bun.lock" \
     -type f 2>/dev/null \
     | sort \
-    | xargs shasum -a 256 2>/dev/null \
-    | shasum -a 256 \
+    | xargs sha256sum 2>/dev/null \
+    | sha256sum \
     | cut -d' ' -f1
 }
 


### PR DESCRIPTION
修复issue：#227 
- Dockerfile: apk add 加入 bash，补全 scripts/ 目录复制
- scripts/embed-frontend.sh: shasum 替换为 sha256sum（Alpine 兼容）