### PR TITLE
fix(providers): 兼容 vLLM 新版响应中的 reasoning 字段

### DIFF
--- a/backend-go/internal/converters/chat_to_responses.go
+++ b/backend-go/internal/converters/chat_to_responses.go
@@ -242,8 +242,12 @@ func ConvertOpenAIChatToResponses(ctx context.Context, modelName string, origina
 
 		finishReason := choice.Get("finish_reason").String()
 
-		// 处理 reasoning_content（OpenAI o1 模型的原生 reasoning 字段）
-		if reasoning := delta.Get("reasoning_content"); reasoning.Exists() && reasoning.String() != "" {
+		// 处理推理内容：优先 reasoning_content（OpenAI/DeepSeek），回退 reasoning（vLLM）
+		reasoning := delta.Get("reasoning_content")
+		if !reasoning.Exists() || reasoning.String() == "" {
+			reasoning = delta.Get("reasoning")
+		}
+		if reasoning.Exists() && reasoning.String() != "" {
 			out = append(out, st.handleReasoningPart(reasoning.String(), nextSeq)...)
 		}
 
@@ -1086,8 +1090,12 @@ func ConvertOpenAIChatToResponsesNonStream(_ context.Context, _ string, original
 			continue
 		}
 
-		// 处理 reasoning_content
-		if reasoning := message.Get("reasoning_content"); reasoning.Exists() && reasoning.String() != "" {
+		// 处理推理内容：优先 reasoning_content（OpenAI/DeepSeek），回退 reasoning（vLLM）
+		reasoning := message.Get("reasoning_content")
+		if !reasoning.Exists() || reasoning.String() == "" {
+			reasoning = message.Get("reasoning")
+		}
+		if reasoning.Exists() && reasoning.String() != "" {
 			reasoningBuf.WriteString(reasoning.String())
 		}
 

--- a/backend-go/internal/converters/chat_to_responses_nonstream_test.go
+++ b/backend-go/internal/converters/chat_to_responses_nonstream_test.go
@@ -74,6 +74,40 @@ func TestConvertOpenAIChatToResponsesNonStream(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIChatToResponsesNonStream_VLLMReasoning(t *testing.T) {
+	ctx := context.Background()
+	chatResponse := `{
+		"id": "chatcmpl-vllm",
+		"object": "chat.completion",
+		"created": 1234567890,
+		"model": "glm-5.2",
+		"choices": [{
+			"index": 0,
+			"message": {
+				"role": "assistant",
+				"reasoning": "vllm reasoning",
+				"content": "final answer"
+			},
+			"finish_reason": "stop"
+		}],
+		"usage": {
+			"prompt_tokens": 10,
+			"completion_tokens": 8,
+			"total_tokens": 18
+		}
+	}`
+
+	result := ConvertOpenAIChatToResponsesNonStream(ctx, "glm-5.2", []byte(`{"model":"glm-5.2","input":"Hi"}`), nil, []byte(chatResponse), nil)
+	parsed := gjson.Parse(result)
+
+	if got := parsed.Get(`output.#(type=="reasoning").summary.0.text`).String(); got != "vllm reasoning" {
+		t.Fatalf("reasoning summary = %q, want vllm reasoning; result=%s", got, result)
+	}
+	if got := parsed.Get(`output.#(type=="message").content.0.text`).String(); got != "final answer" {
+		t.Fatalf("message text = %q, want final answer; result=%s", got, result)
+	}
+}
+
 func TestConvertOpenAIChatToResponsesNonStream_ToolCalls(t *testing.T) {
 	ctx := context.Background()
 

--- a/backend-go/internal/converters/chat_to_responses_stream_test.go
+++ b/backend-go/internal/converters/chat_to_responses_stream_test.go
@@ -96,6 +96,34 @@ func TestConvertOpenAIChatToResponses_StreamReasoningContent(t *testing.T) {
 	}
 }
 
+func TestConvertOpenAIChatToResponses_StreamVLLMReasoning(t *testing.T) {
+	ctx := context.Background()
+	sseLines := []string{
+		`data: {"id":"chatcmpl-vllm","object":"chat.completion.chunk","created":1234567890,"model":"glm-5.2","choices":[{"index":0,"delta":{"reasoning":"vllm reasoning"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-vllm","object":"chat.completion.chunk","created":1234567890,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"chat text"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-vllm","object":"chat.completion.chunk","created":1234567890,"model":"glm-5.2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+	}
+
+	var state any
+	var allEvents []string
+	for _, line := range sseLines {
+		events := ConvertOpenAIChatToResponses(ctx, "glm-5.2", []byte(`{"model":"glm-5.2","input":"hello"}`), nil, []byte(line), &state)
+		allEvents = append(allEvents, events...)
+	}
+
+	joined := strings.Join(allEvents, "\n")
+	if !strings.Contains(joined, `"type":"reasoning"`) {
+		t.Fatalf("expected reasoning item, got %v", allEvents)
+	}
+	if !strings.Contains(joined, `"text":"vllm reasoning"`) {
+		t.Fatalf("expected reasoning summary text from vLLM reasoning, got %v", allEvents)
+	}
+	if !strings.Contains(joined, `"delta":"chat text"`) {
+		t.Fatalf("expected text delta after reasoning, got %v", allEvents)
+	}
+}
+
 func TestConvertOpenAIChatToResponses_ToolCall(t *testing.T) {
 	ctx := context.Background()
 

--- a/backend-go/internal/converters/gemini_converter.go
+++ b/backend-go/internal/converters/gemini_converter.go
@@ -274,7 +274,11 @@ func OpenAIResponseToGemini(openaiResp map[string]interface{}) (*types.GeminiRes
 
 	// 处理 message
 	if message, ok := choice["message"].(map[string]interface{}); ok {
-		if reasoning, ok := message["reasoning_content"].(string); ok && reasoning != "" {
+		reasoning, _ := message["reasoning_content"].(string)
+		if reasoning == "" {
+			reasoning, _ = message["reasoning"].(string)
+		}
+		if reasoning != "" {
 			parts = append(parts, types.GeminiPart{
 				Text:    reasoning,
 				Thought: true,

--- a/backend-go/internal/converters/gemini_converter_test.go
+++ b/backend-go/internal/converters/gemini_converter_test.go
@@ -141,3 +141,26 @@ func TestOpenAIResponseToGemini_WithThoughtSignature(t *testing.T) {
 		}
 	})
 }
+
+func TestOpenAIResponseToGemini_VLLMReasoningField(t *testing.T) {
+	openaiResp := map[string]interface{}{
+		"choices": []interface{}{
+			map[string]interface{}{
+				"message": map[string]interface{}{
+					"reasoning": "vllm reasoning",
+					"content":   "final answer",
+				},
+			},
+		},
+	}
+
+	geminiResp, err := OpenAIResponseToGemini(openaiResp)
+	assert.NoError(t, err)
+	assert.NotNil(t, geminiResp)
+	assert.Len(t, geminiResp.Candidates, 1)
+	assert.NotNil(t, geminiResp.Candidates[0].Content)
+	assert.Len(t, geminiResp.Candidates[0].Content.Parts, 2)
+	assert.True(t, geminiResp.Candidates[0].Content.Parts[0].Thought)
+	assert.Equal(t, "vllm reasoning", geminiResp.Candidates[0].Content.Parts[0].Text)
+	assert.Equal(t, "final answer", geminiResp.Candidates[0].Content.Parts[1].Text)
+}

--- a/backend-go/internal/converters/responses_converter.go
+++ b/backend-go/internal/converters/responses_converter.go
@@ -842,6 +842,9 @@ func OpenAIChatResponseToResponses(openaiResp map[string]interface{}, sessionID 
 		if ok {
 			message, _ := choice["message"].(map[string]interface{})
 			reasoningFromField, _ := message["reasoning_content"].(string)
+			if reasoningFromField == "" {
+				reasoningFromField, _ = message["reasoning"].(string)
+			}
 			contentRaw, _ := message["content"].(string)
 			remainingContent, extractedThinking, hasThink := extractThinkTag(contentRaw)
 			// 合并：原生 reasoning_content 优先，再追加从 <think> 提取出的内容

--- a/backend-go/internal/converters/responses_converter_think_test.go
+++ b/backend-go/internal/converters/responses_converter_think_test.go
@@ -103,6 +103,29 @@ func TestOpenAIChatResponseToResponses_ThinkMergesWithReasoningContent(t *testin
 	assert.Equal(t, "visible", firstContentText(t, resp.Output[1]))
 }
 
+func TestOpenAIChatResponseToResponses_VLLMReasoningField(t *testing.T) {
+	openaiResp := map[string]interface{}{
+		"model": "glm-5.2",
+		"choices": []interface{}{
+			map[string]interface{}{
+				"message": map[string]interface{}{
+					"role":      "assistant",
+					"reasoning": "vllm reasoning",
+					"content":   "visible",
+				},
+			},
+		},
+	}
+
+	resp, err := OpenAIChatResponseToResponses(openaiResp, "sess_test")
+	assert.NoError(t, err)
+	assert.Len(t, resp.Output, 2)
+	assert.Equal(t, "reasoning", resp.Output[0].Type)
+	assert.Equal(t, "vllm reasoning", summaryText(t, resp.Output[0]))
+	assert.Equal(t, "message", resp.Output[1].Type)
+	assert.Equal(t, "visible", firstContentText(t, resp.Output[1]))
+}
+
 // TestOpenAIChatResponseToResponses_ThinkInMiddleNotStripped 验证 content 非起始位置出现
 // 的 <think> 字面不应被剥离。
 func TestOpenAIChatResponseToResponses_ThinkInMiddleNotStripped(t *testing.T) {

--- a/backend-go/internal/handlers/common/empty_response.go
+++ b/backend-go/internal/handlers/common/empty_response.go
@@ -128,8 +128,12 @@ func isChatMessageEmpty(msg map[string]interface{}) bool {
 		return allMalformed
 	}
 
-	// 3. reasoning_content / refusal 非空也视为有效
-	if rc, ok := msg["reasoning_content"].(string); ok && !IsEffectivelyEmptyStreamText(rc) {
+	// 3. reasoning_content（或 vLLM 的 reasoning）/ refusal 非空也视为有效
+	rc, _ := msg["reasoning_content"].(string)
+	if rc == "" {
+		rc, _ = msg["reasoning"].(string)
+	}
+	if !IsEffectivelyEmptyStreamText(rc) {
 		return false
 	}
 	if refusal, ok := msg["refusal"].(string); ok && strings.TrimSpace(refusal) != "" {

--- a/backend-go/internal/handlers/common/empty_response_test.go
+++ b/backend-go/internal/handlers/common/empty_response_test.go
@@ -110,6 +110,15 @@ func TestIsChatResponseEmpty(t *testing.T) {
 				}},
 			},
 		}, false},
+		{"vllm reasoning", map[string]interface{}{
+			"choices": []interface{}{
+				map[string]interface{}{"message": map[string]interface{}{
+					"role":      "assistant",
+					"content":   "",
+					"reasoning": "thinking...",
+				}},
+			},
+		}, false},
 		{"refusal", map[string]interface{}{
 			"choices": []interface{}{
 				map[string]interface{}{"message": map[string]interface{}{

--- a/backend-go/internal/handlers/common/stream_processor.go
+++ b/backend-go/internal/handlers/common/stream_processor.go
@@ -446,7 +446,11 @@ func HasOpenAIChatSemanticContent(event string) bool {
 			if content, _ := delta["content"].(string); !IsEffectivelyEmptyStreamText(content) {
 				return true
 			}
-			if reasoning, _ := delta["reasoning_content"].(string); !IsEffectivelyEmptyStreamText(reasoning) {
+			reasoning, _ := delta["reasoning_content"].(string)
+			if reasoning == "" {
+				reasoning, _ = delta["reasoning"].(string)
+			}
+			if !IsEffectivelyEmptyStreamText(reasoning) {
 				return true
 			}
 			if functionCall, ok := delta["function_call"].(map[string]interface{}); ok && len(functionCall) > 0 {

--- a/backend-go/internal/handlers/common/stream_test.go
+++ b/backend-go/internal/handlers/common/stream_test.go
@@ -846,6 +846,11 @@ func TestHasOpenAIChatSemanticContent(t *testing.T) {
 			want:  true,
 		},
 		{
+			name:  "vllm reasoning delta",
+			event: `data: {"choices":[{"delta":{"reasoning":"thinking"}}]}` + "\n\n",
+			want:  true,
+		},
+		{
 			name:  "legacy function call name",
 			event: `data: {"choices":[{"delta":{"function_call":{"name":"Read"}}}]}` + "\n\n",
 			want:  true,

--- a/backend-go/internal/handlers/gemini/deepseek_thinking_matrix_test.go
+++ b/backend-go/internal/handlers/gemini/deepseek_thinking_matrix_test.go
@@ -42,6 +42,24 @@ func TestGeminiHandler_DeepSeekChatAndMessagesThinkingMatrix(t *testing.T) {
 			},
 		},
 		{
+			name:         "gemini_to_vllm_chat_reasoning",
+			serviceType:  "openai",
+			responseBody: `{"id":"chatcmpl_vllm","object":"chat.completion","choices":[{"message":{"role":"assistant","reasoning":"vllm reasoning","content":"chat text"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+			wantUpstream: func(t *testing.T, body []byte) {
+				if !bytes.Contains(body, []byte(`"reasoning_content":"previous reasoning"`)) {
+					t.Fatalf("expected upstream OpenAI reasoning_content, got %s", string(body))
+				}
+			},
+			wantDownstream: func(t *testing.T, body []byte) {
+				if !bytes.Contains(body, []byte(`"text":"vllm reasoning"`)) || !bytes.Contains(body, []byte(`"thought":true`)) {
+					t.Fatalf("expected Gemini thought part from vLLM reasoning, got %s", string(body))
+				}
+				if !bytes.Contains(body, []byte(`"text":"chat text"`)) {
+					t.Fatalf("expected Gemini text part, got %s", string(body))
+				}
+			},
+		},
+		{
 			name:         "gemini_to_deepseek_messages",
 			serviceType:  "claude",
 			responseBody: `{"id":"msg_ds","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"messages thinking","signature":"sig_ds"},{"type":"text","text":"messages text"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":2}}`,
@@ -124,6 +142,18 @@ func TestGeminiHandler_DeepSeekChatAndMessagesStreamThinkingMatrix(t *testing.T)
 				``,
 			}, "\n"),
 			wantText: "chat reasoning",
+		},
+		{
+			name:        "gemini_stream_to_vllm_chat_reasoning",
+			serviceType: "openai",
+			responseBody: strings.Join([]string{
+				`data: {"id":"chatcmpl_vllm","model":"glm-5.2","choices":[{"delta":{"reasoning":"vllm reasoning"},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl_vllm","model":"glm-5.2","choices":[{"delta":{"content":"chat text"},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl_vllm","model":"glm-5.2","choices":[{"delta":{},"finish_reason":"stop"}]}`,
+				`data: [DONE]`,
+				``,
+			}, "\n"),
+			wantText: "vllm reasoning",
 		},
 		{
 			name:        "gemini_stream_to_deepseek_messages",

--- a/backend-go/internal/handlers/gemini/stream.go
+++ b/backend-go/internal/handlers/gemini/stream.go
@@ -750,7 +750,11 @@ func streamOpenAIToGemini(
 		}
 
 		// 提取文本内容
-		if reasoning, _ := delta["reasoning_content"].(string); reasoning != "" {
+		reasoning, _ := delta["reasoning_content"].(string)
+		if reasoning == "" {
+			reasoning, _ = delta["reasoning"].(string)
+		}
+		if reasoning != "" {
 			geminiChunk := types.GeminiStreamChunk{
 				Candidates: []types.GeminiCandidate{
 					{

--- a/backend-go/internal/handlers/responses/deepseek_thinking_matrix_test.go
+++ b/backend-go/internal/handlers/responses/deepseek_thinking_matrix_test.go
@@ -53,6 +53,33 @@ func TestResponsesHandler_DeepSeekChatAndMessagesThinkingMatrix(t *testing.T) {
 			},
 		},
 		{
+			name:         "responses_to_vllm_chat_reasoning",
+			serviceType:  "openai",
+			responseBody: `{"id":"chatcmpl_vllm","object":"chat.completion","choices":[{"message":{"role":"assistant","reasoning":"vllm reasoning","content":"chat text"},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}`,
+			wantUpstream: func(t *testing.T, body []byte) {
+				var req map[string]interface{}
+				if err := json.Unmarshal(body, &req); err != nil {
+					t.Fatalf("unmarshal upstream request: %v", err)
+				}
+				messages, ok := req["messages"].([]interface{})
+				if !ok || len(messages) < 2 {
+					t.Fatalf("messages shape invalid: %s", string(body))
+				}
+				assistant, ok := messages[0].(map[string]interface{})
+				if !ok {
+					t.Fatalf("assistant reasoning message shape invalid: %s", string(body))
+				}
+				if got := assistant["reasoning_content"]; got != "previous reasoning" {
+					t.Fatalf("reasoning_content = %v, want previous reasoning; body=%s", got, string(body))
+				}
+			},
+			wantDownstream: func(t *testing.T, body []byte) {
+				if !bytes.Contains(body, []byte(`"type":"reasoning"`)) || !bytes.Contains(body, []byte(`"text":"vllm reasoning"`)) {
+					t.Fatalf("expected Responses reasoning item from vLLM reasoning, got %s", string(body))
+				}
+			},
+		},
+		{
 			name:         "responses_to_deepseek_messages",
 			serviceType:  "claude",
 			responseBody: `{"id":"msg_ds","type":"message","role":"assistant","content":[{"type":"thinking","thinking":"messages thinking","signature":"sig_ds"},{"type":"text","text":"messages text"}],"stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":2}}`,
@@ -158,6 +185,23 @@ func TestResponsesHandler_DeepSeekChatAndMessagesStreamThinkingMatrix(t *testing
 			want: []string{
 				`response.reasoning_summary_text.delta`,
 				`"text":"chat reasoning"`,
+				`"delta":"chat text"`,
+				`"type":"response.completed"`,
+			},
+		},
+		{
+			name:        "responses_stream_to_vllm_chat_reasoning",
+			serviceType: "openai",
+			responseBody: strings.Join([]string{
+				`data: {"id":"chatcmpl_vllm","object":"chat.completion.chunk","created":123,"model":"glm-5.2","choices":[{"index":0,"delta":{"reasoning":"vllm reasoning"},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl_vllm","object":"chat.completion.chunk","created":123,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"chat text"},"finish_reason":null}]}`,
+				`data: {"id":"chatcmpl_vllm","object":"chat.completion.chunk","created":123,"model":"glm-5.2","choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}`,
+				`data: [DONE]`,
+				``,
+			}, "\n"),
+			want: []string{
+				`response.reasoning_summary_text.delta`,
+				`"text":"vllm reasoning"`,
 				`"delta":"chat text"`,
 				`"type":"response.completed"`,
 			},

--- a/backend-go/internal/providers/openai.go
+++ b/backend-go/internal/providers/openai.go
@@ -344,10 +344,10 @@ func (p *OpenAIProvider) ConvertToClaudeResponse(providerResp *types.ProviderRes
 		msg := choice.Message
 
 		// 添加文本内容
-		if msg.ReasoningContent != "" {
+		if reasoning := msg.GetReasoningContent(); reasoning != "" {
 			claudeResp.Content = append(claudeResp.Content, types.ClaudeContent{
 				Type:     "thinking",
-				Thinking: msg.ReasoningContent,
+				Thinking: reasoning,
 			})
 		}
 
@@ -498,8 +498,12 @@ func (p *OpenAIProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 				model = m
 			}
 
-			// 处理 reasoning_content（DeepSeek Chat / OpenAI 兼容推理内容）
-			if reasoning, ok := delta["reasoning_content"].(string); ok && reasoning != "" {
+			// 处理推理内容：优先 reasoning_content（DeepSeek/OpenAI），回退 reasoning（vLLM）
+			reasoning, _ := delta["reasoning_content"].(string)
+			if reasoning == "" {
+				reasoning, _ = delta["reasoning"].(string)
+			}
+			if reasoning != "" {
 				if !messageStartSent {
 					eventChan <- buildMessageStartEvent(model)
 					messageStartSent = true

--- a/backend-go/internal/providers/sse_normalization_test.go
+++ b/backend-go/internal/providers/sse_normalization_test.go
@@ -136,6 +136,45 @@ func TestOpenAIProvider_HandleStreamResponse_MapsReasoningContentToThinkingDelta
 	}
 }
 
+// TestOpenAIProvider_HandleStreamResponse_MapsVLLMReasoningToThinkingDelta 验证 vLLM 的
+// reasoning 字段（非 reasoning_content）也能正确映射为 Claude thinking 事件
+func TestOpenAIProvider_HandleStreamResponse_MapsVLLMReasoningToThinkingDelta(t *testing.T) {
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-vllm","model":"glm-5.2","choices":[{"delta":{"reasoning":"让我思考"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-vllm","model":"glm-5.2","choices":[{"delta":{"reasoning":"一下"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-vllm","model":"glm-5.2","choices":[{"delta":{"content":"你好！"},"finish_reason":null}]}`,
+		`data: {"id":"chatcmpl-vllm","model":"glm-5.2","choices":[{"delta":{},"finish_reason":"stop"}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	provider := &OpenAIProvider{}
+	eventChan, errChan, err := provider.HandleStreamResponse(io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatalf("HandleStreamResponse returned error: %v", err)
+	}
+
+	events := collectStreamEvents(eventChan)
+	select {
+	case streamErr := <-errChan:
+		if streamErr != nil {
+			t.Fatalf("unexpected stream error: %v", streamErr)
+		}
+	default:
+	}
+
+	joined := strings.Join(events, "\n")
+	if !strings.Contains(joined, `"type":"thinking"`) {
+		t.Fatalf("expected thinking content block from vLLM reasoning field, got %v", events)
+	}
+	if !strings.Contains(joined, `"type":"thinking_delta"`) || !strings.Contains(joined, `"thinking":"让我思考"`) {
+		t.Fatalf("expected thinking_delta from vLLM reasoning, got %v", events)
+	}
+	if !strings.Contains(joined, `"type":"text_delta"`) || !strings.Contains(joined, `"text":"你好！"`) {
+		t.Fatalf("expected text delta after reasoning, got %v", events)
+	}
+}
+
 func TestGeminiProvider_HandleStreamResponse_AcceptsNoSpaceDataLines(t *testing.T) {
 	body := strings.Join([]string{
 		`data:{"candidates":[{"content":{"parts":[{"text":"OK"}]},"finishReason":"STOP"}]}`,

--- a/backend-go/internal/providers/sse_normalization_test.go
+++ b/backend-go/internal/providers/sse_normalization_test.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/BenedictKing/ccx/internal/types"
 )
 
 func TestNormalizeSSEFieldLine(t *testing.T) {
@@ -172,6 +174,35 @@ func TestOpenAIProvider_HandleStreamResponse_MapsVLLMReasoningToThinkingDelta(t 
 	}
 	if !strings.Contains(joined, `"type":"text_delta"`) || !strings.Contains(joined, `"text":"你好！"`) {
 		t.Fatalf("expected text delta after reasoning, got %v", events)
+	}
+}
+
+func TestOpenAIProvider_ConvertToClaudeResponse_MapsVLLMReasoningToThinking(t *testing.T) {
+	provider := &OpenAIProvider{}
+	claudeResp, err := provider.ConvertToClaudeResponse(&types.ProviderResponse{
+		Body: []byte(`{
+			"id": "chatcmpl-vllm",
+			"choices": [{
+				"message": {
+					"role": "assistant",
+					"reasoning": "vllm reasoning",
+					"content": "final answer"
+				},
+				"finish_reason": "stop"
+			}]
+		}`),
+	})
+	if err != nil {
+		t.Fatalf("ConvertToClaudeResponse() error = %v", err)
+	}
+	if len(claudeResp.Content) != 2 {
+		t.Fatalf("Content len = %d, want 2: %#v", len(claudeResp.Content), claudeResp.Content)
+	}
+	if claudeResp.Content[0].Type != "thinking" || claudeResp.Content[0].Thinking != "vllm reasoning" {
+		t.Fatalf("expected vLLM reasoning mapped to thinking block, got %#v", claudeResp.Content[0])
+	}
+	if claudeResp.Content[1].Type != "text" || claudeResp.Content[1].Text != "final answer" {
+		t.Fatalf("expected text block after thinking, got %#v", claudeResp.Content[1])
 	}
 }
 

--- a/backend-go/internal/types/types.go
+++ b/backend-go/internal/types/types.go
@@ -83,8 +83,17 @@ type OpenAIMessage struct {
 	Role             string           `json:"role"`
 	Content          interface{}      `json:"content"` // string 或 null
 	ReasoningContent string           `json:"reasoning_content,omitempty"`
+	Reasoning        string           `json:"reasoning,omitempty"` // vLLM 兼容：新版 vLLM 使用 reasoning 而非 reasoning_content
 	ToolCalls        []OpenAIToolCall `json:"tool_calls,omitempty"`
 	ToolCallID       string           `json:"tool_call_id,omitempty"`
+}
+
+// GetReasoningContent 返回推理内容，优先 reasoning_content，回退 reasoning（vLLM 兼容）
+func (m *OpenAIMessage) GetReasoningContent() string {
+	if m.ReasoningContent != "" {
+		return m.ReasoningContent
+	}
+	return m.Reasoning
 }
 
 // OpenAIToolCall OpenAI 工具调用


### PR DESCRIPTION
## Summary

- 新版 vLLM (0.11.x+) 在 chat completions 响应中使用 `delta.reasoning` / `message.reasoning` 传递推理内容，而非此前的 `reasoning_content`，导致经 CCX 协议转换后思考内容被静默丢弃
- 所有上游响应解析路径统一增加回退逻辑：优先 `reasoning_content`，缺失时回退 `reasoning`，对 DeepSeek/OpenAI 等已有上游完全兼容

## 复现场景

用户以 Claude Messages / Responses / Gemini 格式接入 CCX，上游为 vLLM 部署的模型（如 GLM-5.2），思考内容全部丢失。

上游流式响应示例（vLLM 0.11.x）：
```bash
data: {"id":"chatcmpl-aa44d23147b30a4d","object":"chat.completion.chunk","created":1782310900,"model":"glm-5.2","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"prompt_token_ids":null,"prompt_text":null}

data: {"id":"chatcmpl-aa44d23147b30a4d","object":"chat.completion.chunk","created":1782310900,"model":"glm-5.2","choices":[{"index":0,"delta":{"reasoning":"让我"},"logprobs":null,"finish_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-aa44d23147b30a4d","object":"chat.completion.chunk","created":1782310900,"model":"glm-5.2","choices":[{"index":0,"delta":{"reasoning":"思考"},"logprobs":null,"finish_reason":null,"token_ids":null}]}
```
非流式响应：
```json
{
  "id": "chatcmpl-825fc80224fdc484",
  "object": "chat.completion",
  "created": 1782307789,
  "model": "glm-5.2",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "你好！很高兴认识你。\n\n我是一个由Z.ai开发的大型语言模型。我的知识来源于海量的文本数据，这让我能够理解和生成人类语言。我没有个人情感、意识或真实的物理形态，但我被设计成为一个得力的AI助手，旨在为你提供信息和帮助。\n\n我可以帮你做很多事情，包括但不限于：\n\n*   **回答问题**：涵盖科学、历史、技术、生活常识等多个领域的知识。\n*   **文本创作**：帮你写文章、故事、邮件、总结报告甚至诗歌。\n*   **语言翻译**：支持多种语言之间的互译，帮你打破语言障碍。\n*   **编程辅助**：解答代码问题、提供编写思路、解释技术概念或提供代码片段。\n*   **日常对话**：陪你聊天、进行头脑风暴、提供决策建议或帮你梳理思路。\n\n请问今天有什么我可以帮你的吗？无论是工作、学习还是生活中的问题，都可以随时告诉我哦！",
        "refusal": null,
        "annotations": null,
        "audio": null,
        "function_call": null,
        "tool_calls": [],
        "reasoning": "1.  **分析输入：**\n    *   输入：\"你好，请介绍下你自己\" (你好，请介绍一下你自己)\n    *   意图：用户想了解我的身份、能力以及我作为AI助手的作用。\n    *   语言：中文（简体）。\n\n2.  **确定角色/身份：**\n    *   我是一个大型语言模型。\n    *   由Z.ai开发。\n    *   我的主要功能是根据所训练的海量文本数据协助用户回答问题、提供信息并进行对话。\n\n3.  **构思介绍内容：**\n    *   **问候：**友好地回应。\n    *   **身份：**清晰地说明我是什么（由Z.ai开发的大型语言模型）。\n    *   **能力：**列出我可以做的事情（回答问题、撰写文本、翻译、头脑风暴、编程帮助、对话等）。\n    *   **局限性（可选但属于良好实践）：**提及我没有个人情感或真实的现实世界经验，依赖于训练数据。\n    *   **行动号召：**询问用户今天如何帮助他们。\n\n4.  **起草回复（中文）：**\n    *   *草稿1：* 你好！我是一个由Z.ai训练的大型语言模型。我没有个人情感或真实的物理形态，但我被设计用来帮助你回答问题、提供信息、进行创作和对话。我可以写文章、翻译语言、编程辅助等等。请问今天有什么我可以帮你的吗？\n    *   *润色草稿1（使其更自然、更全面）：* 你好！很高兴认识你。我是一个由Z.ai开发的大型语言模型。\n    我的知识来源于大量的文本数据，这让我能够理解和生成人类语言。我没有个人情感和真实的物理形态，但我可以成为你得力的AI助手。\n    我能做的事情包括但不限于：\n    *   **回答问题**：涵盖科学、历史、生活常识等多个领域。\n    *   **文本创作**：写文章、写故事、写邮件、做诗等。\n    *   **语言翻译**：支持多种语言之间的互译。\n    *   **编程辅助**：解答代码问题、提供编写思路或片段。\n    *   **日常对话**：陪你聊天、头脑风暴、提供建议。\n    请问今天有什么我可以帮你的吗？无论是学习、工作还是日常生活中的问题，都可以随时问我哦！\n\n5.  **最终润色：**生成的草稿看起来很好，礼貌，涵盖了所有必要点，并鼓励进一步的互动。"
      },
      "logprobs": null,
      "finish_reason": "stop",
      "stop_reason": 154827,
      "token_ids": null,
      "routed_experts": null
    }
  ],
  "service_tier": null,
  "system_fingerprint": "vllm-0.11.2.dev279+dark.devotion.pr31.tp6odd16.79f154c.b12x1cfc6cf.fi9c5ed7c.cu132.20260621-tp8-b6f4ac42",
  "usage": {
    "prompt_tokens": 18,
    "total_tokens": 723,
    "completion_tokens": 705,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "multimodal_tokens": null
    }
  },
  "prompt_logprobs": null,
  "prompt_token_ids": null,
  "prompt_text": null,
  "kv_transfer_params": null
}
```

## 修改范围（10 处入口）

| 文件 | 场景 |
|------|------|
| `types.go` | `OpenAIMessage` 新增 `Reasoning` 字段 + `GetReasoningContent()` |
| `openai.go` | Messages←Chat 流式 & 非流式 |
| `stream_processor.go` | 流活跃检测（防误判断流） |
| `empty_response.go` | 空响应检测（防误 failover） |
| `chat_to_responses.go` | Responses←Chat 流式 & 非流式 |
| `responses_converter.go` | Responses←Chat 非流式（converter 路径） |
| `gemini_converter.go` | Gemini←Chat 非流式 |
| `gemini/stream.go` | Gemini←Chat 流式 |

## Test plan

- [x] 新增 `TestOpenAIProvider_HandleStreamResponse_MapsVLLMReasoningToThinkingDelta`
- [x] 原有 `reasoning_content` 测试全部通过，无 regression
- [x] `go test ./internal/...` 全量通过
