### PR TITLE
fix(providers): 跳过空 tool_calls 避免 text block 被拆分

### DIFF
--- a/backend-go/internal/providers/openai.go
+++ b/backend-go/internal/providers/openai.go
@@ -581,8 +581,8 @@ func (p *OpenAIProvider) HandleStreamResponse(body io.ReadCloser) (<-chan string
 				eventChan <- fmt.Sprintf("event: content_block_delta\ndata: %s\n\n", deltaJSON)
 			}
 
-			// 处理工具调用
-			if toolCalls, ok := delta["tool_calls"].([]interface{}); ok {
+			// 处理工具调用（跳过空数组，vLLM 等上游可能在每个 delta 都带 tool_calls:[]）
+			if toolCalls, ok := delta["tool_calls"].([]interface{}); ok && len(toolCalls) > 0 {
 				// 在第一个 content_block 之前发送 message_start
 				if !messageStartSent {
 					eventChan <- buildMessageStartEvent(model)

--- a/backend-go/internal/providers/sse_normalization_test.go
+++ b/backend-go/internal/providers/sse_normalization_test.go
@@ -138,6 +138,49 @@ func TestOpenAIProvider_HandleStreamResponse_MapsReasoningContentToThinkingDelta
 	}
 }
 
+// TestOpenAIProvider_HandleStreamResponse_EmptyToolCallsDoesNotSplitTextBlock 验证
+// vLLM delta 中的空 tool_calls:[] 不会导致 text block 被拆分为多个独立块
+func TestOpenAIProvider_HandleStreamResponse_EmptyToolCallsDoesNotSplitTextBlock(t *testing.T) {
+	// 真实 vLLM 0.22.x 流式响应：每个 delta 都携带空 tool_calls:[]
+	body := strings.Join([]string{
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"prompt_token_ids":null,"prompt_text":null}`,
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"你好","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}`,
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"！有什么","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}`,
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"可以","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}`,
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"帮你的吗","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}`,
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"？😊","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}`,
+		`data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}]}`,
+		`data: [DONE]`,
+		"",
+	}, "\n")
+
+	provider := &OpenAIProvider{}
+	eventChan, errChan, err := provider.HandleStreamResponse(io.NopCloser(strings.NewReader(body)))
+	if err != nil {
+		t.Fatalf("HandleStreamResponse returned error: %v", err)
+	}
+
+	events := collectStreamEvents(eventChan)
+	select {
+	case streamErr := <-errChan:
+		if streamErr != nil {
+			t.Fatalf("unexpected stream error: %v", streamErr)
+		}
+	default:
+	}
+
+	// 应该只有 1 个 content_block_start（type=text），不能被空 tool_calls 拆成多个
+	startCount := 0
+	for _, event := range events {
+		if strings.Contains(event, `"type":"content_block_start"`) {
+			startCount++
+		}
+	}
+	if startCount != 1 {
+		t.Fatalf("expected exactly 1 content_block_start for text, got %d.\nevents: %v", startCount, events)
+	}
+}
+
 // TestOpenAIProvider_HandleStreamResponse_MapsVLLMReasoningToThinkingDelta 验证 vLLM 的
 // reasoning 字段（非 reasoning_content）也能正确映射为 Claude thinking 事件
 func TestOpenAIProvider_HandleStreamResponse_MapsVLLMReasoningToThinkingDelta(t *testing.T) {


### PR DESCRIPTION
## Summary

- vLLM 在每个流式 delta 中都携带 `tool_calls:[]`（空数组），`HandleStreamResponse` 中空数组的类型断言 `.([]interface{})` 成功后误触发 text block 关闭逻辑，导致每个文本片段被独立的 `content_block_start/stop` 包裹
- 增加 `len(toolCalls) > 0` 检查跳过空数组，一行改动

## 复现场景

用户以 Claude Messages 格式（`/v1/messages`）接入 CCX，上游为 vLLM 部署的模型。上游每个 chunk 的 delta 都包含空 `tool_calls`:

```bash
data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"role":"assistant","content":""},"logprobs":null,"finish_reason":null}],"prompt_token_ids":null,"prompt_text":null}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"你好","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"！有什么","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"可以","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"帮你的吗","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{"content":"？😊","tool_calls":[]},"logprobs":null,"finish_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[{"index":0,"delta":{},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}]}

data: {"id":"chatcmpl-ac0e1a6028c01fc8","object":"chat.completion.chunk","created":1782310028,"model":"glm-5.2","choices":[],"usage":{"prompt_tokens":3759,"total_tokens":3770,"completion_tokens":11,"prompt_tokens_details":{"cached_tokens":3584}},"system_fingerprint":"vllm-0.22.1rc1.dev268+g6e426e29c.d20260608-tp4-2f072363"}

data: [DONE]


```

实际收到的 SSE（错误）：
```
content_block_start (index 0) → delta "你好" → content_block_stop
content_block_start (index 1) → delta "！有什么" → content_block_stop
content_block_start (index 2) → delta "可以" → content_block_stop
...
```

修复后（正确）：
```
content_block_start (index 0)
  → delta "你好"
  → delta "！有什么"
  → delta "可以"
  → ...
content_block_stop (index 0)
```

## 修改范围

| 文件 | 改动 |
|------|------|
| `openai.go:585` | `tool_calls` 处理增加 `len > 0` 检查 |

## Test plan

- [x] 新增 `TestOpenAIProvider_HandleStreamResponse_EmptyToolCallsDoesNotSplitTextBlock`
- [x] 现有流式测试全部通过，无 regression
