### PR TITLE
fix(brew): replace deprecated `depends_on` string syntax

### DIFF
--- a/packaging/homebrew/Casks/ccx-desktop.rb.template
+++ b/packaging/homebrew/Casks/ccx-desktop.rb.template
@@ -16,7 +16,7 @@ cask "ccx-desktop" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :catalina"
+  depends_on macos: :catalina
 
   app "CCX Desktop.app"
 end

--- a/packaging/homebrew/update-cask.yml
+++ b/packaging/homebrew/update-cask.yml
@@ -42,7 +42,7 @@ jobs:
               strategy :github_latest
             end
 
-            depends_on macos: ">= :catalina"
+            depends_on macos: :catalina
 
             app "CCX Desktop.app"
           end


### PR DESCRIPTION
替换 `depends_on` 废弃语法。

```shell
Warning: Calling string comparison format for `depends_on macos:` is deprecated! Use `depends_on macos: :catalina` instead.
```