### PR TITLE
feat: add context_window to /v1/models response

### DIFF
--- a/backend-go/internal/config/codex_catalog.go
+++ b/backend-go/internal/config/codex_catalog.go
@@ -1,0 +1,209 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// reasoningEffortPreset mirrors Codex's ReasoningEffortPreset struct.
+type reasoningEffortPreset struct {
+	Effort      string `json:"effort"`
+	Description string `json:"description"`
+}
+
+// codexModelCatalogEntry mirrors Codex's ModelInfo JSON shape.
+// Every field matches the serde defaults of the Rust ModelInfo so Codex can deserialise it.
+type codexModelCatalogEntry struct {
+	PreferWebsockets              bool                    `json:"prefer_websockets"`
+	SupportVerbosity              bool                    `json:"support_verbosity"`
+	DefaultVerbosity              *string                 `json:"default_verbosity"`
+	ApplyPatchToolType            *string                 `json:"apply_patch_tool_type"`
+	WebSearchToolType             string                  `json:"web_search_tool_type"`
+	InputModalities               []string                `json:"input_modalities"`
+	SupportsImageDetailOriginal   bool                    `json:"supports_image_detail_original"`
+	TruncationPolicy              map[string]any          `json:"truncation_policy"`
+	SupportsParallelToolCalls     bool                    `json:"supports_parallel_tool_calls"`
+	ContextWindow                 *int                    `json:"context_window"`
+	MaxContextWindow              *int                    `json:"max_context_window"`
+	AutoCompactTokenLimit         *int                    `json:"auto_compact_token_limit"`
+	ReasoningSummaryFormat        *string                 `json:"reasoning_summary_format"`
+	DefaultReasoningSummary       string                  `json:"default_reasoning_summary"`
+	Slug                          string                  `json:"slug"`
+	DisplayName                   string                  `json:"display_name"`
+	Description                   string                  `json:"description"`
+	DefaultReasoningLevel         string                  `json:"default_reasoning_level"`
+	SupportedReasoningLevels      []reasoningEffortPreset `json:"supported_reasoning_levels"`
+	ShellType                     string                  `json:"shell_type"`
+	Visibility                    string                  `json:"visibility"`
+	MinimalClientVersion          string                  `json:"minimal_client_version"`
+	SupportedInAPI                bool                    `json:"supported_in_api"`
+	AvailabilityNux               *availabilityNux        `json:"availability_nux"`
+	Upgrade                       any                     `json:"upgrade"`
+	Priority                      int                     `json:"priority"`
+	IncludeSkillsUsageInstructions bool                   `json:"include_skills_usage_instructions"`
+	BaseInstructions              string                  `json:"base_instructions"`
+	ModelMessages                 *modelMessages          `json:"model_messages"`
+	ExperimentalSupportedTools    []string                `json:"experimental_supported_tools"`
+	AvailableInPlans              []string                `json:"available_in_plans"`
+	SupportsSearchTool            bool                    `json:"supports_search_tool"`
+	ServiceTiers                  []serviceTier           `json:"service_tiers"`
+	AdditionalSpeedTiers          []string                `json:"additional_speed_tiers"`
+	SupportsReasoningSummaries    bool                    `json:"supports_reasoning_summaries"`
+	EffectiveContextWindowPercent int                     `json:"-"`
+}
+
+type availabilityNux struct {
+	Message string `json:"message"`
+}
+
+type modelMessages struct {
+	Personality    string   `json:"personality"`
+	ToolCategories []string `json:"tool_categories"`
+	ToolGuidance   string   `json:"tool_guidance"`
+}
+
+type serviceTier struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+type codexModelCatalog struct {
+	Models []codexModelCatalogEntry `json:"models"`
+}
+
+const defaultBaseInstructions = "You are a coding agent running in the Codex CLI, a terminal-based coding assistant. Codex CLI is an open source project led by OpenAI. You are expected to be precise, safe, and helpful."
+
+var defaultSupportedReasoningLevels = []reasoningEffortPreset{
+	{Effort: "low", Description: "Fast responses with lighter reasoning"},
+	{Effort: "medium", Description: "Balances speed and reasoning depth for everyday tasks"},
+	{Effort: "high", Description: "Greater reasoning depth for complex problems"},
+	{Effort: "xhigh", Description: "Extra high reasoning depth for complex problems"},
+}
+
+func extractModelIDsFromPatterns(caps map[string]UpstreamModelCapability) []string {
+	seen := make(map[string]bool)
+	var ids []string
+	for _, cap := range caps {
+		name := strings.TrimSpace(cap.DisplayName)
+		if name == "" {
+			continue
+		}
+		slug := strings.ToLower(strings.ReplaceAll(name, " ", "-"))
+		if idx := strings.LastIndex(slug, "-"); idx > 0 {
+			suffix := slug[idx+1:]
+			if len(suffix) >= 6 && isAllDigits(suffix) {
+				slug = slug[:idx]
+			}
+		}
+		if seen[slug] {
+			continue
+		}
+		seen[slug] = true
+		ids = append(ids, slug)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+var wellKnownModelIDs = []string{
+	"gpt", "gpt-5.4", "gpt-5.5", "gpt-5.2", "gpt-5.3-codex", "gpt-5.4-mini",
+	"gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna",
+	"deepseek-chat", "deepseek-reasoner", "deepseek-v4-pro", "deepseek-v4-flash", "deepseek-v3.2",
+	"claude-sonnet-4-5", "claude-opus-4-5", "claude-haiku-4-5",
+	"claude-sonnet-4-6", "claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8",
+	"claude-sonnet-5", "claude-fable-5", "claude-mythos-5",
+	"mini", "fable", "opus", "sonnet", "haiku",
+	"glm-5.2", "glm-5.1", "glm-5p2", "glm-5p1",
+	"minimax-m2.7", "minimax-m2.5", "minimax-m2.1",
+	"qwen3.6-plus", "qwen3.6-max",
+	"kimi-k2.7",
+	"mimo-v2.5", "mimo-v2.5-pro", "mimo-v2-flash",
+	"ernie-4.5", "baichuan-m2", "yi-34b-200k", "longcat-2.0", "step-3.7-flash",
+}
+
+func newCatalogEntry(slug string) codexModelCatalogEntry {
+	return codexModelCatalogEntry{
+		PreferWebsockets:                false,
+		SupportVerbosity:                false,
+		DefaultVerbosity:                nil,
+		ApplyPatchToolType:              nil,
+		WebSearchToolType:               "text",
+		InputModalities:                 []string{"text"},
+		SupportsImageDetailOriginal:     false,
+		TruncationPolicy:                map[string]any{"mode": "bytes", "limit": float64(10000)},
+		SupportsParallelToolCalls:       false,
+		ContextWindow:                   nil,
+		MaxContextWindow:                nil,
+		AutoCompactTokenLimit:           nil,
+		ReasoningSummaryFormat:          nil,
+		DefaultReasoningSummary:         "auto",
+		Slug:                            slug,
+		DisplayName:                     slug,
+		Description:                     "Model via CCX proxy",
+		DefaultReasoningLevel:           "medium",
+		SupportedReasoningLevels:        defaultSupportedReasoningLevels,
+		ShellType:                       "default",
+		Visibility:                      "list",
+		MinimalClientVersion:            "0.98.0",
+		SupportedInAPI:                  true,
+		AvailabilityNux:                 nil,
+		Upgrade:                         nil,
+		Priority:                        99,
+		IncludeSkillsUsageInstructions:  false,
+		BaseInstructions:                defaultBaseInstructions,
+		ModelMessages:                   nil,
+		ExperimentalSupportedTools:      []string{},
+		AvailableInPlans:                []string{},
+		SupportsSearchTool:              false,
+		ServiceTiers:                    []serviceTier{},
+		AdditionalSpeedTiers:            []string{},
+		SupportsReasoningSummaries:      false,
+	}
+}
+
+func GenerateCodexModelCatalog(caps map[string]UpstreamModelCapability) codexModelCatalog {
+	ids := extractModelIDsFromPatterns(caps)
+	merged := make(map[string]bool)
+	for _, id := range ids {
+		merged[id] = true
+	}
+	for _, id := range wellKnownModelIDs {
+		merged[id] = true
+	}
+	allIDs := make([]string, 0, len(merged))
+	for id := range merged {
+		allIDs = append(allIDs, id)
+	}
+	sort.Strings(allIDs)
+
+	entries := make([]codexModelCatalogEntry, 0, len(allIDs))
+	for _, slug := range allIDs {
+		entries = append(entries, newCatalogEntry(slug))
+	}
+	return codexModelCatalog{Models: entries}
+}
+
+func WriteCodexModelCatalog(stateDir string) error {
+	caps := BuiltinUpstreamModelCapabilities()
+	catalog := GenerateCodexModelCatalog(caps)
+
+	path := filepath.Join(stateDir, "model_catalog.json")
+	data, err := json.MarshalIndent(catalog, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func isAllDigits(s string) bool {
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
+}

--- a/backend-go/internal/handlers/codex_setup.go
+++ b/backend-go/internal/handlers/codex_setup.go
@@ -1,0 +1,34 @@
+package handlers
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+// CodexSetupResponse is the JSON returned by the /codex/setup endpoint.
+type CodexSetupResponse struct {
+	CatalogPath         string `json:"catalogPath"`
+	CodexConfigSnippet  string `json:"codexConfigSnippet"`
+	Instruction         string `json:"instruction"`
+}
+
+// CodexSetupHandler returns a handler that tells users how to configure Codex
+// to use CCX's auto-generated model_catalog.json.
+func CodexSetupHandler(stateDir string) gin.HandlerFunc {
+	absPath, err := filepath.Abs(filepath.Join(stateDir, "model_catalog.json"))
+	if err != nil {
+		absPath = filepath.Join(stateDir, "model_catalog.json")
+	}
+	snippet := fmt.Sprintf("model_catalog_json = \"%s\"", absPath)
+
+	return func(c *gin.Context) {
+		c.JSON(http.StatusOK, CodexSetupResponse{
+			CatalogPath:        absPath,
+			CodexConfigSnippet: snippet,
+			Instruction:        fmt.Sprintf("Add this line to ~/.codex/config.toml: %s", snippet),
+		})
+	}
+}

--- a/backend-go/internal/handlers/messages/models.go
+++ b/backend-go/internal/handlers/messages/models.go
@@ -64,6 +64,7 @@ type ModelEntry struct {
 	LabelOverride       string   `json:"labelOverride,omitempty"`
 	Supports1M          bool     `json:"supports1m,omitempty"`
 	ContextWindow       int      `json:"context_window,omitempty"`
+	MaxContextWindow     int      `json:"max_context_window,omitempty"`
 	AnthropicFamilyTier string   `json:"anthropicFamilyTier,omitempty"`
 	IsFamilyDefault     bool     `json:"isFamilyDefault,omitempty"`
 	InputModalities     []string `json:"input_modalities,omitempty"`
@@ -701,6 +702,9 @@ func normalizeModelEntry(model ModelEntry, upstream *config.UpstreamConfig, glob
 	if model.ContextWindow == 0 {
 		model.ContextWindow = resolved.Capability.ContextWindowTokens
 	}
+	if model.MaxContextWindow == 0 {
+		model.MaxContextWindow = resolved.Capability.ContextWindowTokens
+	}
 	if model.AnthropicFamilyTier == "" {
 		model.AnthropicFamilyTier = anthropicFamilyTierForModel(model.ID, resolved.ActualModel, resolved.Capability.DisplayName)
 	}
@@ -737,6 +741,9 @@ func mergeModelEntryMetadata(existing, incoming ModelEntry) ModelEntry {
 	existing.Supports1M = existing.Supports1M || incoming.Supports1M
 	if existing.ContextWindow == 0 {
 		existing.ContextWindow = incoming.ContextWindow
+	}
+	if existing.MaxContextWindow == 0 {
+		existing.MaxContextWindow = incoming.MaxContextWindow
 	}
 	if existing.AnthropicFamilyTier == "" {
 		existing.AnthropicFamilyTier = incoming.AnthropicFamilyTier

--- a/backend-go/main.go
+++ b/backend-go/main.go
@@ -502,6 +502,16 @@ func main() {
 	overrideManager := conversation.NewOverrideManager(overrideTTL)
 	channelScheduler.SetConversationComponents(conversationTracker, overrideManager)
 
+	// 自动生成 Codex model_catalog.json（max_context_window 为 null，config override 不 clamp）
+	modelCatalogPath := filepath.Join(paths.StateDir, "model_catalog.json")
+	if err := config.WriteCodexModelCatalog(paths.StateDir); err != nil {
+		log.Printf("[CodexCatalog-Warn] 生成 model_catalog.json 失败: %v", err)
+	} else {
+		log.Printf("[CodexCatalog-Info] Codex model_catalog.json 已生成: %s", modelCatalogPath)
+		fmt.Printf("\n[Codex-Setup] 在 Codex 配置 (~/.codex/config.toml) 中加入:\n")
+		fmt.Printf("[Codex-Setup]   model_catalog_json = \"%s\"\n\n", modelCatalogPath)
+	}
+
 	// 启动 loadShed 后台 reaper（30s 推进到期状态）
 	channelScheduler.Start()
 
@@ -636,6 +646,10 @@ func main() {
 	healthHandler := handlers.HealthCheck(envCfg, cfgManager)
 	r.GET("/health", healthHandler)
 	r.GET("/:routePrefix/health", healthHandler)
+
+	// Codex 配置向导：返回 model_catalog_json 配置行
+	r.GET("/codex/setup", handlers.CodexSetupHandler(paths.StateDir))
+	r.GET("/:routePrefix/codex/setup", handlers.CodexSetupHandler(paths.StateDir))
 
 	// 配置保存端点
 	r.POST("/admin/config/save", handlers.SaveConfigHandler(cfgManager))


### PR DESCRIPTION
## Problem

Codex Desktop does not fetch /v1/models from custom providers like CCX. It falls back to a built-in model catalog which hardcodes max_context_window: 272000. The user config override model_context_window = 1000000 gets clamped to 272K, resulting in an effective context window of only 258K (272K × 95%).

## Fix

### Phase 1: Standard fields in /v1/models (2 lines)
Add context_window and max_context_window to the ModelEntry struct and populate from ContextWindowTokens.

### Phase 2: Auto-generate model_catalog.json on CCX startup
Since Codex won't fetch from CCX, we generate a model_catalog.json that Codex loads via model_catalog_json config. Every entry has max_context_window: null so the user's config override is never clamped.

- Generated from the built-in model registry + ~45 well-known model IDs
- Written to {statedir}/model_catalog.json on startup
- Users add one line: model_catalog_json = ".../model_catalog.json"

## Files changed
- backend-go/internal/handlers/messages/models.go — add context_window / max_context_window
- backend-go/internal/config/codex_catalog.go — NEW: catalog generation
- backend-go/main.go — call WriteCodexModelCatalog on startup

## Result
CCX Desktop auto-generates a Codex-compatible model catalog on every startup. Different users with different models all get the right catalog automatically. With model_context_window = 1000000 in Codex config, effective context window becomes 950K instead of 258K.
