### PR TITLE
feat(provider): add OrcaRouter as a named provider template

### DIFF
--- a/backend-go/internal/config/provider_templates.go
+++ b/backend-go/internal/config/provider_templates.go
@@ -300,6 +300,18 @@ var builtinProviderTemplates = []ProviderTemplate{
 		}),
 	),
 	newProviderTemplate(
+		"orcarouter",
+		"OrcaRouter",
+		"OrcaRouter 多模型聚合网关",
+		"relay",
+		"second",
+		standardProviderRoutes("openai", []ProviderCandidate{
+			{BaseURL: "https://api.orcarouter.ai/v1", PlanTag: "payg", Region: "global", Priority: 0},
+		}, []ProviderCandidate{
+			{BaseURL: "https://api.orcarouter.ai/v1", PlanTag: "payg", Region: "global", Priority: 0},
+		}),
+	),
+	newProviderTemplate(
 		"modelscope",
 		"ModelScope 魔搭",
 		"阿里 ModelScope 官方推理服务",

--- a/backend-go/internal/config/provider_templates_test.go
+++ b/backend-go/internal/config/provider_templates_test.go
@@ -244,6 +244,7 @@ func TestListAndGetProviderTemplate(t *testing.T) {
 	for _, id := range []string{
 		"mimo", "deepseek", "kimi", "glm", "volcengine", "compshare", "sensenova", "minimax",
 		"dashscope", "opencode-zen", "tencent-lkeap", "qianfan", "xfyun", "openrouter", "modelscope", "originrouter",
+		"orcarouter",
 	} {
 		if _, ok := GetProviderTemplate(id); !ok {
 			t.Errorf("缺少 provider 模板: %s", id)

--- a/desktop/frontend/src/utils/providerDisplay.ts
+++ b/desktop/frontend/src/utils/providerDisplay.ts
@@ -21,6 +21,7 @@ const PROVIDER_BRAND_NAMES: Record<string, string> = {
   qianfan: '百度千帆',
   xfyun: '讯飞星辰',
   openrouter: 'OpenRouter',
+  orcarouter: 'OrcaRouter',
   modelscope: 'ModelScope 魔搭',
   originrouter: '极易云 OriginRouter'
 }

--- a/frontend/src/utils/providerDisplay.ts
+++ b/frontend/src/utils/providerDisplay.ts
@@ -21,6 +21,7 @@ const PROVIDER_BRAND_NAMES: Record<string, string> = {
   qianfan: '百度千帆',
   xfyun: '讯飞星辰',
   openrouter: 'OpenRouter',
+  orcarouter: 'OrcaRouter',
   modelscope: 'ModelScope 魔搭',
   originrouter: '极易云 OriginRouter'
 }


### PR DESCRIPTION
## Summary

This registers [OrcaRouter](https://www.orcarouter.ai) the same way the existing OpenRouter provider is wired, so the channel setup and provider display stay consistent. OrcaRouter is an OpenAI-compatible gateway: one `ORCAROUTER_API_KEY` (keys start with `sk-orca-`) unlocks 150+ models from OpenAI, Anthropic, Google, DeepSeek, Qwen, MiniMax and xAI behind a single `https://api.orcarouter.ai/v1` endpoint. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

## What this changes

- `backend-go/internal/config/provider_templates.go`: add an `orcarouter` entry to the built-in provider template registry using `standardProviderRoutes("openai", ...)` — the same pattern `opencode-zen` uses for OpenAI-only providers. The template yields `messages` / `chat` / `responses` routes all pointing at `https://api.orcarouter.ai/v1` (payg, global), so a channel can be created with just an `sk-orca-` key.
- `backend-go/internal/config/provider_templates_test.go`: add `orcarouter` to the `TestListAndGetProviderTemplate` enumeration.
- `frontend/src/utils/providerDisplay.ts` and `desktop/frontend/src/utils/providerDisplay.ts`: add `orcarouter: 'OrcaRouter'` to `PROVIDER_BRAND_NAMES`.

## Verification

- `go build ./internal/...`, `go vet ./internal/...` — pass.
- `go test ./internal/config/...` and `go test ./internal/handlers/...` — pass.
- `bun build` on both `providerDisplay.ts` files — pass; output contains `orcarouter: "OrcaRouter"`.
- Runtime check: `GetProviderTemplate("orcarouter")` returns the expected routes (`messages`/`chat`/`responses`, `serviceType=openai`, `baseURL=https://api.orcarouter.ai/v1`) and appears in `ListProviderTemplates()`.
- Live check against `https://api.orcarouter.ai/v1` with a real key: `orcarouter/auto` returns 200.

I'm an engineer on the OrcaRouter team.
