### PR TITLE
fix(frontend): preserve escaped base URL paths

### DIFF
--- a/frontend/src/utils/base-url-semantics.test.ts
+++ b/frontend/src/utils/base-url-semantics.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  buildExpectedRequestUrl,
+  deduplicateEquivalentBaseUrls,
+  stripDashboardPathFromBaseUrl
+} from './baseUrlSemantics'
+
+describe('base URL 路径语义', () => {
+  it('显式 # 应保留与控制台同名的 API 路径并跳过版本前缀补全', () => {
+    const baseUrl = 'https://example.com/token/v1#'
+
+    expect(deduplicateEquivalentBaseUrls([baseUrl], 'openai')).toEqual([baseUrl])
+    expect(buildExpectedRequestUrl('openai', '/chat/completions', baseUrl)).toBe(
+      'https://example.com/token/v1/chat/completions'
+    )
+  })
+
+  it('未使用 # 时仍应清理明确的控制台路径', () => {
+    expect(stripDashboardPathFromBaseUrl('https://example.com/console/token')).toBe('https://example.com')
+  })
+})

--- a/frontend/src/utils/baseUrlSemantics.ts
+++ b/frontend/src/utils/baseUrlSemantics.ts
@@ -26,14 +26,13 @@ export function stripDashboardPathFromBaseUrl(rawUrl: string): string {
   const trimmed = rawUrl.trim()
   if (!trimmed) return ''
 
-  const hasHash = trimmed.endsWith('#')
-  const withoutHash = hasHash ? trimmed.slice(0, -1) : trimmed
+  if (trimmed.endsWith('#')) return trimmed
 
   try {
-    const parsed = new URL(withoutHash)
+    const parsed = new URL(trimmed)
     const path = parsed.pathname.toLowerCase()
     if (dashboardPathPrefixes.some(prefix => path === prefix || path.startsWith(prefix + '/'))) {
-      return parsed.origin + (hasHash ? '#' : '')
+      return parsed.origin
     }
   } catch {
     return trimmed


### PR DESCRIPTION
## 结论

修复带路径 Base URL 的显式 `#` 逃生语义：当用户填写 `https://example.com/token/v1#` 时，前端不再把 `/token/v1` 误判为控制台路径并截成域名根路径。

Fixes #276

## 问题与根因

`stripDashboardPathFromBaseUrl` 会先移除尾部 `#`，再按 `dashboardPathPrefixes` 清理路径。由于列表包含 `/token`，即使用户已经用 `#` 明确要求保留原始路径，`/token/v1` 仍会被截断，导致：

- 保存后的 Base URL 变成 `https://example.com#`
- 预期请求地址错误地变成 `https://example.com/chat/completions`

## 方案与取舍

- 让尾部 `#` 优先于控制台路径清理：检测到显式 `#` 后直接保留原值。
- 未带 `#` 的 URL 仍按原有规则清理 `/console`、`/token` 等常见控制台路径，避免改变快速添加的默认启发式行为。
- 不新增配置项，也不改变后端 URL 拼接规则。

## 测试

通过：

- `bun run test`（40 个测试文件，423 个测试通过）
- `bun run type-check`
- `bun run build`
- `bunx eslint src/utils/baseUrlSemantics.ts src/utils/base-url-semantics.test.ts`
- `bunx prettier --check src/utils/base-url-semantics.test.ts`
- `git diff --check`

回归测试已做 sabotage 验证：临时恢复旧逻辑后，新测试会稳定失败并得到 `https://example.com#`；恢复修复后通过。

说明：仓库级 `bun run lint` 当前仍因本 PR 未触及的既有问题失败（`useEditChannelModal.ts` 与 `env.d.ts` 的 `no-multiple-empty-lines` 等，共 7 个 error、38 个 warning）；本 PR 改动文件的定向 ESLint 检查通过。

## 风险与兼容性

- 风险较低，仅影响以 `#` 结尾的 Base URL；该后缀本来就是 CCX 的显式“不要自动补版本路径”语义。
- 不带 `#` 的历史配置与控制台 URL 清理行为保持不变。
- 未覆盖范围：不尝试自动判断无 `#` 的 `/token` 究竟是控制台路径还是 API 前缀，仍由用户通过 `#` 明确表达。

## AI 披露

本 PR 内容由 AI 辅助生成，并遵循仓库现有约定完成了测试、构建与差异审查。
